### PR TITLE
fix(licensee): isWindows is a function

### DIFF
--- a/rules/license-detectable-by-licensee.js
+++ b/rules/license-detectable-by-licensee.js
@@ -7,7 +7,7 @@ const spawnSync = require('child_process').spawnSync
 module.exports = function (targetDir, options) {
   const expected = '\nLicense: ([^\n]*)'
 
-  const licenseeOutput = spawnSync(isWindows ? 'licensee.bat' : 'licensee', [targetDir]).stdout
+  const licenseeOutput = spawnSync(isWindows() ? 'licensee.bat' : 'licensee', [targetDir]).stdout
 
   if (licenseeOutput == null) {
     return {


### PR DESCRIPTION
licensee does not work on Linux, isWindows is a function, see https://www.npmjs.com/package/is-windows