### PR TITLE
Make readme-references-license case-insensitive

### DIFF
--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -10,8 +10,9 @@ module.exports = function (targetDir, options) {
 
   files.forEach(file => {
     const content = fs.getFileContents(file)
+    const regexp = new RegExp(options.content, options.flags)
 
-    if (content && content.toString().match(options.content)) {
+    if (content && content.toString().search(regexp) !== -1) {
       passes.push(`File ${file} contains ${options.content}`)
     } else {
       failures.push(`File ${file} doesn't contain ${options.content}`)

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -5,7 +5,7 @@
       "readme-file-exists:file-existence": ["error", {"files": ["README*"]}],
       "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIB*"]}],
       "code-of-conduct-file-exists:file-existence": ["error", {"files": ["CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT"]}],
-      "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license"}],
+      "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll"]}],
       "license-detectable-by-licensee": ["error"],
       "test-directory-exists:directory-existence": ["error", {"directories": ["test*", "specs"]}],


### PR DESCRIPTION
To avoid false-negatives when the README.md references the LICENSE file,
make the readme-references-license rule case-insensitive.

To do so, support passing RegExp flags via the options.