### PR TITLE
Fix the regex to match the license reported by licensee

### DIFF
--- a/rules/license-detectable-by-licensee.js
+++ b/rules/license-detectable-by-licensee.js
@@ -5,7 +5,7 @@ const isWindows = require('is-windows')
 const spawnSync = require('child_process').spawnSync
 
 module.exports = function (targetDir, options) {
-  const expected = '\nLicense: ([^\n]*)'
+  const expected = /License: ([^\n]+)/
 
   const licenseeOutput = spawnSync(isWindows() ? 'licensee.bat' : 'licensee', [targetDir]).stdout
 


### PR DESCRIPTION
At least with licensee 9.2.1 there is no leading '\n' anymore. Fix the
regex to match in any case.