### PR TITLE
Add a new ruleset with Git-related checks

### DIFF
--- a/rules/git-grep-commits.js
+++ b/rules/git-grep-commits.js
@@ -1,0 +1,32 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const spawnSync = require('child_process').spawnSync
+
+function grepCommits (targetDir, patterns) {
+  let result = ''
+
+  const pattern = '(' + patterns.join('|') + ')'
+  const args = ['-C', targetDir, 'rev-list', '--all']
+  const revisions = spawnSync('git', args).stdout.toString()
+  revisions.split('\n').forEach((commit) => {
+    const args = ['-C', targetDir, 'grep', '-E', '-i', pattern, commit]
+    result += spawnSync('git', args).stdout.toString()
+  })
+
+  return result
+}
+
+module.exports = function (targetDir, options) {
+  const result = grepCommits(targetDir, options.blacklist)
+
+  if (result) {
+    return {
+      failures: [`The following commits contain blacklisted words:\n${result}`]
+    }
+  }
+
+  return {
+    passes: ['No blacklisted words found in any commits.']
+  }
+}

--- a/rules/git-grep-log.js
+++ b/rules/git-grep-log.js
@@ -1,0 +1,25 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const spawnSync = require('child_process').spawnSync
+
+function grepLog (targetDir, patterns) {
+  const args = ['-C', targetDir, 'log', '--all', '--format=full', '-E', '-i']
+    .concat(patterns.map(pattern => `--grep=${pattern}`))
+  const log = spawnSync('git', args).stdout.toString()
+  return log
+}
+
+module.exports = function (targetDir, options) {
+  const result = grepLog(targetDir, options.blacklist)
+
+  if (result) {
+    return {
+      failures: [`The following commit messages contain blacklisted words:\n${result}`]
+    }
+  }
+
+  return {
+    passes: ['No blacklisted words found in any commit messages.']
+  }
+}

--- a/rules/git-list-tree.js
+++ b/rules/git-list-tree.js
@@ -1,0 +1,37 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const spawnSync = require('child_process').spawnSync
+
+function listFiles (targetDir, patterns) {
+  let result = []
+
+  const pattern = '(' + patterns.join('|') + ')'
+  const args = ['-C', targetDir, 'rev-list', '--all']
+  const revisions = spawnSync('git', args).stdout.toString()
+  revisions.split('\n').forEach((commit) => {
+    const args = ['-C', targetDir, 'ls-tree', '-r', '--name-only', commit]
+    const list = spawnSync('git', args).stdout.toString()
+    list.split('\n').forEach((path) => {
+      if (path.match(pattern)) {
+        result.push({ 'commit': commit, 'path': path })
+      }
+    })
+  })
+
+  return result
+}
+
+module.exports = function (targetDir, options) {
+  const result = listFiles(targetDir, options.blacklist)
+
+  if (result.length > 0) {
+    return {
+      failures: [`The following commits contain blacklisted paths:\n${JSON.stringify(result, null, 4)}`]
+    }
+  }
+
+  return {
+    passes: ['No blacklisted paths found in any commits.']
+  }
+}

--- a/rules/git-working-tree.js
+++ b/rules/git-working-tree.js
@@ -1,0 +1,31 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const spawnSync = require('child_process').spawnSync
+
+module.exports = function (targetDir, options) {
+  const args = ['-C', targetDir, 'rev-parse', '--show-prefix']
+  const result = spawnSync('git', args)
+  if (result.status === 0) {
+    const prefix = result.stdout.toString().trim()
+    if (!prefix) {
+      return {
+        passes: ['The directory is managed with Git, and it is the root directory.']
+      }
+    }
+
+    if (options.allowSubDir) {
+      return {
+        passes: ['The sub-directory is managed with Git.']
+      }
+    } else {
+      return {
+        failures: ['The sub-directory is managed with Git, but need to check the root directory.']
+      }
+    }
+  } else {
+    return {
+      failures: ['The directory is not managed with Git.']
+    }
+  }
+}

--- a/rulesets/git.json
+++ b/rulesets/git.json
@@ -3,7 +3,8 @@
     "all": {
       "dir-is-managed-with-git:git-working-tree": ["warning", {"allowSubDir": false}],
       "git-log-contains-no-blacklisted-words:git-grep-log": ["error", {"blacklist": ["secret", "password"]}],
-      "git-commits-contain-no-blacklisted-words:git-grep-commits": ["error", {"blacklist": ["secret", "password"]}]
+      "git-commits-contain-no-blacklisted-words:git-grep-commits": ["error", {"blacklist": ["secret", "password"]}],
+      "git-tree-contains-no-blacklisted-files:git-list-tree": ["error", {"blacklist": ["secret", "password"]}]
     }
   }
 }

--- a/rulesets/git.json
+++ b/rulesets/git.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "all": {
+      "dir-is-managed-with-git:git-working-tree": ["warning", {"allowSubDir": false}],
       "git-log-contains-no-blacklisted-words:git-grep-log": ["error", {"blacklist": ["secret", "password"]}],
       "git-commits-contain-no-blacklisted-words:git-grep-commits": ["error", {"blacklist": ["secret", "password"]}]
     }

--- a/rulesets/git.json
+++ b/rulesets/git.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "all": {
+      "git-log-contains-no-blacklisted-words:git-grep-log": ["error", {"blacklist": ["secret", "password"]}],
+      "git-commits-contain-no-blacklisted-words:git-grep-commits": ["error", {"blacklist": ["secret", "password"]}]
+    }
+  }
+}


### PR DESCRIPTION
The git ruleset contains two new rules that search the commit messages
and the commits themselves for configurable blacklisted words. These
words can in fact be extended regular expressions. This is a new ruleset
instead of adding the rules to the default ruleset as these checks can be
a bit time consuming, depending on the size of the Git history.