### PR TITLE
Allow the config file to be named repolinter.json as a fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All languages:
 Currently you need to create a new ruleset to add, remove, or configure rules. We'll be adding the ability to inherit from an existing ruleset to simplify this in the future.
 
 ### Overriding the ruleset globally or for a project
-To override the default ruleset copy ```rulesets/default.json``` to ```repolint.json``` in the target directory, any ancenstor directory of the target directory, or your user directory.
+To override the default ruleset copy ```rulesets/default.json``` to ```repolint.json``` (or ```repolinter.json```) in the target directory, any ancenstor directory of the target directory, or your user directory.
 
 ### Disabling rules
 To disable a rule change it's value to ```false```, for example:

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = function (targetDir) {
   console.log(`Target directory: ${targetDir}`)
 
   let rulesetPath = findConfig('repolint.json', {cwd: targetDir})
+  rulesetPath = rulesetPath || findConfig('repolinter.json', {cwd: targetDir})
   rulesetPath = rulesetPath || path.join(__dirname, 'rulesets/default.json')
 
   console.log(`Ruleset: ${rulesetPath}`)


### PR DESCRIPTION
It may be more convenient to name the config file exactly like the tool,
so allow also "repolinter.json" as a name.