### PR TITLE
Refactor the rules to return a new Result class

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,19 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Run mocha",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "stopOnEntry": false,
+
+      "args": ["${file}", "--no-timeouts"],
+
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": null,
+      "env": { "NODE_ENV": "testing"}
+  },
+    {
       "type": "node",
       "request": "launch",
       "name": "Launch Program",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ bin/repolinter.js
 ✔ license-detectable-by-licensee: Licensee identified the license for project: Apache License 2.0
 ✔ test-directory-exists: found (tests)
 ✔ source-license-headers-exist: exist
+✔ package-metadata-exists: found (Gemfile)
+✔ package-metadata-exists: found (package.json)
 ```
 
 ## Command line dependencies
@@ -43,7 +45,7 @@ Run `bundle install` to get Lincensee and Linguist support.
 ## Custom Result Formatter
 By default, results will be shown as in the example format above.
 
-When using `repolinter` in another project, you can set `resultFormatter` to a custom formatter. Any custom formatter needs to have a `format` function that takes three arguments `(rule, message, level)`, and returns a string.
+When using `repolinter` in another project, you can set `resultFormatter` to a custom formatter. Any custom formatter needs to have a `format` function that takes a single [Result](./lib/result.js) argument, and returns a string.
 
 ## Default ruleset
 The default ruleset (```rulesets/default.json```) enables the following rules:

--- a/formatters/json_formatter.js
+++ b/formatters/json_formatter.js
@@ -2,14 +2,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 class JsonFormatter {
-  format (rule, message, level) {
-    let output = {
-      rule: rule.id,
-      message: message,
-      level: level
-    }
-
-    return JSON.stringify(output)
+  format (result) {
+    return JSON.stringify(result)
   }
 }
 

--- a/formatters/symbol_formatter.js
+++ b/formatters/symbol_formatter.js
@@ -4,8 +4,8 @@
 const logSymbols = require('log-symbols')
 
 class SymbolFormatter {
-  format (rule, message, level) {
-    return `${logSymbols[level]} ${rule.id}: ${message}`
+  format (result) {
+    return `${logSymbols[result.getStatus()]} ${result.rule.id}: ${result.message}`
   }
 }
 

--- a/lib/result.js
+++ b/lib/result.js
@@ -1,0 +1,32 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const symbolFormatter = require('../formatters/symbol_formatter')
+const jsonFormatter = require('../formatters/json_formatter')
+
+class Result {
+  constructor (rule, message, target, passed) {
+    this.rule = rule
+    this.message = message
+    this.target = target
+    this.passed = passed
+  }
+
+  toString () {
+    return symbolFormatter.format(this)
+  }
+
+  toJson () {
+    return jsonFormatter.format(this)
+  }
+
+  getStatus () {
+    if (this.passed) {
+      return 'success'
+    } else {
+      return this.rule.level
+    }
+  }
+}
+
+module.exports = Result

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,11 @@
         "type-detect": "4.0.3"
       }
     },
+    "chai-string": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.4.0.tgz",
+      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk="
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",

--- a/rules/directory-existence.js
+++ b/rules/directory-existence.js
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 const fileExistence = require('./file-existence')
-module.exports = function (targetDir, options) {
-  options.files = options.directories
-  return fileExistence(targetDir, options)
+module.exports = function (targetDir, rule) {
+  rule.options.files = rule.options.directories
+  return fileExistence(targetDir, rule)
 }

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -1,31 +1,21 @@
 // Copyright 2017 TODO Group. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
+const Result = require('../lib/result')
 
-module.exports = function (targetDir, options) {
+module.exports = function (targetDir, rule) {
+  const options = rule.options
   const fs = options.fs || require('../lib/file_system')
   const files = fs.findAll(targetDir, options.files)
-  const failures = []
-  const passes = []
-  const result = {}
 
-  files.forEach(file => {
-    const content = fs.getFileContents(file)
+  const results = files.map(file => {
+    const fileContents = fs.getFileContents(file)
     const regexp = new RegExp(options.content, options.flags)
 
-    if (content && content.toString().search(regexp) !== -1) {
-      passes.push(`File ${file} contains ${options.content}`)
-    } else {
-      failures.push(`File ${file} doesn't contain ${options.content}`)
-    }
+    const passed = fileContents && fileContents.toString().search(regexp) !== -1
+    const message = `File ${file} ${passed ? 'contains' : 'doesn\'t contain'} ${options.content}`
+
+    return new Result(rule, message, file, passed)
   })
 
-  if (failures.length > 0) {
-    result.failures = failures
-  }
-
-  if (passes.length > 0) {
-    result.passes = passes
-  }
-
-  return result
+  return results
 }

--- a/rules/file-existence.js
+++ b/rules/file-existence.js
@@ -2,17 +2,23 @@
 // Licensed under the Apache License, Version 2.0.
 
 const path = require('path')
+const Result = require('../lib/result')
 
-module.exports = function (targetDir, options) {
+module.exports = function (targetDir, rule) {
+  const options = rule.options
   const fs = options.fs || require('../lib/file_system')
   const file = fs.findFirst(targetDir, options.files)
-  if (file) {
-    return {
-      passes: [`found (${path.relative(targetDir, file)})`]
-    }
+
+  const passed = !!file
+  let result = new Result(rule, '', file, passed)
+
+  if (passed) {
+    result.target = path.relative(targetDir, file)
+    result.message = `found (${result.target})`
+  } else {
+    result.target = targetDir
+    result.message = `not found`
   }
 
-  return {
-    failures: [`not found`]
-  }
+  return [result]
 }

--- a/rules/file-starts-with.js
+++ b/rules/file-starts-with.js
@@ -2,22 +2,31 @@
 // Licensed under the Apache License, Version 2.0.
 
 const path = require('path')
+const Result = require('../lib/result')
 
-module.exports = function (targetDir, options) {
+module.exports = function (targetDir, rule) {
+  const options = rule.options
   const fs = options.fs || require('../lib/file_system')
   const files = fs.findAll(targetDir, options.files)
-  const failures = []
+
+  let results = []
   files.forEach(file => {
+    const target = path.relative(targetDir, file)
     const lines = fs.readLines(file, options.lineCount)
-    const allMatch = options.patterns.every(pattern => {
-      return lines.match(pattern)
+    const misses = options.patterns.filter(pattern => {
+      return !lines.match(pattern)
     })
-    if (!allMatch) {
-      failures.push(path.relative(targetDir, file) + ' doesn\'t contain all the patterns')
-    };
+
+    let message = `The first ${options.lineCount} lines of '${target}'`
+    const passed = misses.length === 0
+    if (passed) {
+      message += ` contain all of the requested patterns.`
+    } else {
+      message += ` do not contain the patterns:\n\t${misses.join('\n\t')}`
+    }
+
+    results.push(new Result(rule, message, target, passed))
   })
-  return {
-    failures: failures,
-    passes: failures.length === 0 ? ['exist'] : []
-  }
+
+  return results
 }

--- a/rules/file-type-exclusion.js
+++ b/rules/file-type-exclusion.js
@@ -1,15 +1,25 @@
 // Copyright 2017 TODO Group. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
+const path = require('path')
+const Result = require('../lib/result')
 
-module.exports = function (targetDir, options) {
+module.exports = function (targetDir, rule) {
+  const options = rule.options
   const fs = options.fs || require('../lib/file_system')
   const files = fs.findAll(targetDir, options.type)
-  if (files && files.length > 0) {
-    return {
-      failures: [`Excluded file type exists (${files})`]
-    }
+
+  const results = files.map(file => {
+    const message = `Excluded file type exists (${file})`
+    const target = path.relative(targetDir, file)
+
+    return new Result(rule, message, target, false)
+  })
+
+  if (results.length === 0) {
+    const message = `Excluded file type doesn't exist (${options.type})`
+
+    results.push(new Result(rule, message, targetDir, true))
   }
-  return {
-    passes: [`Excluded file type doesn't exist (${options.type})`]
-  }
+
+  return results
 }

--- a/rules/git-grep-commits.js
+++ b/rules/git-grep-commits.js
@@ -2,31 +2,48 @@
 // Licensed under the Apache License, Version 2.0.
 
 const spawnSync = require('child_process').spawnSync
+const Result = require('../lib/result')
 
 function grepCommits (targetDir, patterns, ignoreCase) {
-  let result = ''
-
   const pattern = '(' + patterns.join('|') + ')'
-  const args = ['-C', targetDir, 'rev-list', '--all']
-  const revisions = spawnSync('git', args).stdout.toString()
-  revisions.split('\n').forEach((commit) => {
-    const args = ['-C', targetDir, 'grep', '-E', ignoreCase ? '-i' : '', pattern, commit]
-    result += spawnSync('git', args).stdout.toString()
-  })
+  const revisions = grepRevisions(targetDir)
+  const commits = revisions.map((revision) => {
+    return { hash: revision, files: grepFiles(targetDir, pattern, ignoreCase, revision) }
+  }).filter(commit => commit.files.length > 0)
 
-  return result
+  return commits
 }
 
-module.exports = function (targetDir, options) {
-  const result = grepCommits(targetDir, options.blacklist, options.ignoreCase)
+function grepRevisions (targetDir) {
+  const args = ['-C', targetDir, 'rev-list', '--all']
+  return spawnSync('git', args).stdout.toString().trim().split('\n')
+}
 
-  if (result) {
-    return {
-      failures: [`The following commits contain blacklisted words:\n${result}`]
-    }
+function grepFiles (targetDir, pattern, ignoreCase, revision) {
+  const args = ['-C', targetDir, 'grep', '-E', ignoreCase ? '-i' : '', pattern, revision]
+  return spawnSync('git', args).stdout.toString().split('\n').filter(x => !!x).map((entry) => {
+    const [path, ...rest] = entry.substring(revision.length + 1).split(':')
+    return { path: path, text: rest.join(':') }
+  })
+}
+
+module.exports = function (targetDir, rule) {
+  const options = rule.options
+  const commits = grepCommits(targetDir, options.blacklist, options.ignoreCase)
+
+  let results = commits.map(commit => {
+    const result = new Result(rule, '', commit.hash, false)
+    const fileInfo = commit.files.map(file => {
+      return `\t${file.path}: ${file.text}`
+    }).join('\n')
+    result.message = `Commit ${commit.hash} contains blacklisted words:\n${fileInfo}`
+    result.extra = commit.files
+    return result
+  })
+
+  if (results.length === 0) {
+    results.push(new Result(rule, 'No blacklisted words found in any commits.', '', true))
   }
 
-  return {
-    passes: ['No blacklisted words found in any commits.']
-  }
+  return results
 }

--- a/rules/git-working-tree.js
+++ b/rules/git-working-tree.js
@@ -2,30 +2,33 @@
 // Licensed under the Apache License, Version 2.0.
 
 const spawnSync = require('child_process').spawnSync
+const Result = require('../lib/result')
 
-module.exports = function (targetDir, options) {
+module.exports = function (targetDir, rule) {
+  const options = rule.options
   const args = ['-C', targetDir, 'rev-parse', '--show-prefix']
-  const result = spawnSync('git', args)
-  if (result.status === 0) {
-    const prefix = result.stdout.toString().trim()
+  const gitResult = spawnSync('git', args)
+  let result = new Result(rule, '', targetDir)
+  if (gitResult.status === 0) {
+    const prefix = gitResult.stdout.toString().trim()
     if (!prefix) {
-      return {
-        passes: ['The directory is managed with Git, and it is the root directory.']
-      }
+      result.message = 'The directory is managed with Git, and it is the root directory.'
+      result.passed = true
+      return [result]
     }
 
     if (options.allowSubDir) {
-      return {
-        passes: ['The sub-directory is managed with Git.']
-      }
+      result.message = 'The sub-directory is managed with Git.'
+      result.passed = true
+      return [result]
     } else {
-      return {
-        failures: ['The sub-directory is managed with Git, but need to check the root directory.']
-      }
+      result.message = 'The sub-directory is managed with Git, but need to check the root directory.'
+      result.passed = false
+      return [result]
     }
   } else {
-    return {
-      failures: ['The directory is not managed with Git.']
-    }
+    result.message = 'The directory is not managed with Git.'
+    result.passed = false
+    return [result]
   }
 }

--- a/tests/formatters/json_formatter_tests.js
+++ b/tests/formatters/json_formatter_tests.js
@@ -3,18 +3,27 @@
 
 const chai = require('chai')
 const expect = chai.expect
+const Result = require('../../lib/result')
 
 describe('formatters', () => {
   describe('json_formatter', () => {
     it('returns a json string with the correct info', () => {
       const jsonFormatter = require('../../formatters/json_formatter')
-      const rule = {id: 'some-rule'}
 
-      const successResult = jsonFormatter.format(rule, 'a message', 'success')
-      expect(successResult).to.deep.equal(`{"rule":"some-rule","message":"a message","level":"success"}`)
+      const result = new Result(
+        { id: 'some-rule', level: 'success' },
+        'a message',
+        'target',
+        true
+      )
 
-      const errorResult = jsonFormatter.format(rule, 'a message', 'error')
-      expect(errorResult).to.deep.equal(`{"rule":"some-rule","message":"a message","level":"error"}`)
+      const successResult = jsonFormatter.format(result)
+      expect(successResult).to.equal(`{"rule":{"id":"some-rule","level":"success"},"message":"a message","target":"target","passed":true}`)
+
+      result.passed = false
+      result.rule.level = 'error'
+      const errorResult = jsonFormatter.format(result)
+      expect(errorResult).to.deep.equal(`{"rule":{"id":"some-rule","level":"error"},"message":"a message","target":"target","passed":false}`)
     })
   })
 })

--- a/tests/formatters/symbol_formatter_tests.js
+++ b/tests/formatters/symbol_formatter_tests.js
@@ -4,18 +4,26 @@
 const chai = require('chai')
 const expect = chai.expect
 const logSymbols = require('log-symbols')
+const Result = require('../../lib/result')
 
 describe('formatters', () => {
   describe('symbol_formatter', () => {
     it('returns a simple string with the correct log symbol', () => {
       const symbolFormatter = require('../../formatters/symbol_formatter')
-      const rule = {id: 'some-rule'}
 
-      const successResult = symbolFormatter.format(rule, 'a message', 'success')
+      let result = new Result(
+        { id: 'some-rule', level: 'success' },
+        'a message',
+        'target',
+        true
+      )
+      const successResult = symbolFormatter.format(result)
       const successSymbol = logSymbols['success']
       expect(successResult).to.deep.equal(`${successSymbol} some-rule: a message`)
 
-      const errorResult = symbolFormatter.format(rule, 'a message', 'error')
+      result.rule.level = 'error'
+      result.passed = false
+      const errorResult = symbolFormatter.format(result)
       const errorSymbol = logSymbols['error']
       expect(errorResult).to.deep.equal(`${errorSymbol} some-rule: a message`)
     })

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -3,61 +3,90 @@
 
 const chai = require('chai')
 const expect = chai.expect
+const Result = require('../../lib/result')
 
 describe('rule', () => {
   describe('files_contents', () => {
-    it('returns passes if requested file contents exists', () => {
-      const fileContents = require('../../rules/file-contents')
-      const result = fileContents('.', {
-        fs: {
-          findAll () {
-            return ['README.md']
-          },
-          getFileContents () {
-            return 'foo'
-          }
-        },
-        files: ['README*'],
-        content: 'foo'
-      })
+    const fileContents = require('../../rules/file-contents')
 
-      expect(result).to.deep.equal({ passes: ['File README.md contains foo'] })
+    it('returns passes if requested file contents exists', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return ['README.md']
+            },
+            getFileContents () {
+              return 'foo'
+            }
+          },
+          files: ['README*'],
+          content: 'foo'
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'File README.md contains foo',
+            'README.md',
+            true
+          )
+      ]
+
+      const actual = fileContents('.', rule)
+      expect(actual).to.deep.equal(expected)
     })
 
     it('returns fails if requested file contents does not exist', () => {
-      const fileContents = require('../../rules/file-contents')
-      const result = fileContents('.', {
-        fs: {
-          findAll () {
-            return ['README.md']
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return ['README.md']
+            },
+            getFileContents () {
+              return 'foo'
+            }
           },
-          getFileContents () {
-            return 'foo'
-          }
-        },
-        files: ['README*'],
-        content: 'bar'
-      })
+          files: ['README*'],
+          content: 'bar'
+        }
+      }
 
-      expect(result).to.deep.equal({ failures: ['File README.md doesn\'t contain bar'] })
+      const expected = [
+        new Result(
+            rule,
+            'File README.md doesn\'t contain bar',
+            'README.md',
+            false
+          )
+      ]
+
+      const actual = fileContents('.', rule)
+
+      expect(actual).to.deep.equal(expected)
     })
 
     it('returns nothing if requested file does not exist', () => {
-      const fileContents = require('../../rules/file-contents')
-      const result = fileContents('.', {
-        fs: {
-          findAll () {
-            return []
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return []
+            },
+            getFileContents () {
+
+            }
           },
-          getFileContents () {
+          file: 'README.md',
+          content: 'foo'
+        }
+      }
 
-          }
-        },
-        file: 'README.md',
-        content: 'foo'
-      })
-
-      expect(result).to.deep.equal({})
+      const actual = fileContents('.', rule)
+      const expected = []
+      expect(actual).to.deep.equal(expected)
     })
   })
 })

--- a/tests/rules/file_existence_tests.js
+++ b/tests/rules/file_existence_tests.js
@@ -3,36 +3,63 @@
 
 const chai = require('chai')
 const expect = chai.expect
+const Result = require('../../lib/result')
 
 describe('rule', () => {
   describe('files_existence', () => {
-    it('returns passes if requested file exists', () => {
-      const fileExistence = require('../../rules/file-existence')
-      const result = fileExistence('.', {
-        fs: {
-          findFirst () {
-            return 'foo'
-          }
-        },
-        files: ['LICENSE*'],
-        name: 'License file'
-      })
+    const fileExistence = require('../../rules/file-existence')
 
-      expect(result).to.deep.equal({ passes: ['found (foo)'] })
+    it('returns a passed result if requested file exists', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirst () {
+              return 'LICENSE.md'
+            }
+          },
+          files: ['LICENSE*'],
+          name: 'License file'
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'found (LICENSE.md)',
+            'LICENSE.md',
+            true
+          )
+      ]
+
+      const actual = fileExistence('.', rule)
+
+      expect(actual).to.deep.equal(expected)
     })
 
-    it('returns failures if requested file doesn\'t exist', () => {
-      const fileExistence = require('../../rules/file-existence')
-      const result = fileExistence('.', {
-        fs: {
-          findFirst () {
-          }
-        },
-        files: ['LICENSE*'],
-        name: 'License file'
-      })
+    it('returns a failure result if requested file doesn\'t exist', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirst () {
+            }
+          },
+          files: ['LICENSE*'],
+          name: 'License file'
+        }
+      }
 
-      expect(result).to.deep.equal({ failures: ['not found'] })
+      const expected = [
+        new Result(
+            rule,
+            'not found',
+            '.',
+            false
+          )
+      ]
+
+      const actual = fileExistence('.', rule)
+
+      expect(actual).to.deep.equal(expected)
     })
   })
 })

--- a/tests/rules/file_starts_with_tests.js
+++ b/tests/rules/file_starts_with_tests.js
@@ -1,0 +1,83 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const chai = require('chai')
+const expect = chai.expect
+const Result = require('../../lib/result')
+
+describe('rule', () => {
+  describe('file-starts-with', () => {
+    const fileStartsWith = require('../../rules/file-starts-with')
+
+    it('returns a passed result if requested file matches the patterns', () => {
+      const rule = {
+        options: {
+          files: ['rules/file-starts-with.js'],
+          lineCount: 2,
+          patterns: ['Copyright', 'All rights reserved', 'Licensed under']
+        }
+      }
+
+      const expected = [new Result(
+        rule,
+        `The first 2 lines of 'rules/file-starts-with.js' contain all of the requested patterns.`,
+        'rules/file-starts-with.js',
+        true
+      )]
+
+      const actual = fileStartsWith('.', rule)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns a failure result if requested file doesn\'t match all the patterns', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return ['somefile.js']
+            },
+            readLines () {
+              return 'some javascript code'
+            }
+          },
+          files: ['*.js'],
+          lineCount: 5,
+          patterns: ['javascript', 'Copyright', 'Rights']
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            `The first 5 lines of 'somefile.js' do not contain the patterns:\n\tCopyright\n\tRights`,
+            'somefile.js',
+            false
+          )
+      ]
+
+      const actual = fileStartsWith('.', rule)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns an empty list if the request files don\'t exist', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return []
+            }
+          },
+          files: ['*'],
+          lineCount: 1,
+          patterns: ['something']
+        }
+      }
+
+      const actual = fileStartsWith('.', rule)
+
+      expect(actual.length).to.equal(0)
+    })
+  })
+})

--- a/tests/rules/file_type_exclusion_tests.js
+++ b/tests/rules/file_type_exclusion_tests.js
@@ -3,34 +3,59 @@
 
 const chai = require('chai')
 const expect = chai.expect
+const Result = require('../../lib/result')
 
 describe('rule', () => {
   describe('file_type_exclusion', () => {
-    it('returns passes if requested file type doesn\'t exist', () => {
-      const fileTypeExclusion = require('../../rules/file-type-exclusion')
-      const result = fileTypeExclusion('.', {
-        fs: {
-          findAll () {
-          }
-        },
-        type: ['*.dll']
-      })
+    const fileTypeExclusion = require('../../rules/file-type-exclusion')
 
-      expect(result).to.deep.equal({ passes: ['Excluded file type doesn\'t exist (*.dll)'] })
+    it('returns passed result if requested file type doesn\'t exist', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return []
+            }
+          },
+          type: ['*.dll']
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'Excluded file type doesn\'t exist (*.dll)',
+            '.',
+            true
+          )
+      ]
+      const actual = fileTypeExclusion('.', rule)
+
+      expect(actual).to.deep.equal(expected)
     })
 
-    it('returns failures if requested file type exists', () => {
-      const fileTypeExclusion = require('../../rules/file-type-exclusion')
-      const result = fileTypeExclusion('.', {
-        fs: {
-          findAll () {
-            return 'foo.dll'
-          }
-        },
-        type: ['*.dll']
-      })
+    it('returns failed result if requested file type exists', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return ['foo.dll']
+            }
+          },
+          type: ['*.dll']
+        }
+      }
+      const expected = [
+        new Result(
+            rule,
+            'Excluded file type exists (foo.dll)',
+            'foo.dll',
+            false
+          )
+      ]
+      const actual = fileTypeExclusion('.', rule)
 
-      expect(result).to.deep.equal({ failures: ['Excluded file type exists (foo.dll)'] })
+      expect(actual).to.deep.equal(expected)
     })
   })
 })

--- a/tests/rules/git_working_tree_tests.js
+++ b/tests/rules/git_working_tree_tests.js
@@ -12,42 +12,34 @@ describe('rule', () => {
 
     it('passes if the specified directory is managed with Git', () => {
       const result = gitWorkingTree('.', {
-        allowSubDir: false
+        options: { allowSubDir: false }
       })
 
-      expect(result).to.deep.equal({
-        passes: ['The directory is managed with Git, and it is the root directory.']
-      })
+      expect(result[result.length - 1].message).to.equal('The directory is managed with Git, and it is the root directory.')
     })
 
     it('passes if the specified sub-directory is managed in Git and sub-directories are allowed', () => {
       const result = gitWorkingTree('tests', {
-        allowSubDir: true
+        options: { allowSubDir: true }
       })
 
-      expect(result).to.deep.equal({
-        passes: ['The sub-directory is managed with Git.']
-      })
+      expect(result[result.length - 1].message).to.equal('The sub-directory is managed with Git.')
     })
 
     it('fails if the specified sub-directory is managed in Git but sub-directories are not allowed', () => {
       const result = gitWorkingTree('tests', {
-        allowSubDir: false
+        options: { allowSubDir: false }
       })
 
-      expect(result).to.deep.equal({
-        failures: ['The sub-directory is managed with Git, but need to check the root directory.']
-      })
+      expect(result[result.length - 1].message).to.equal('The sub-directory is managed with Git, but need to check the root directory.')
     })
 
     it('fails if the specified directory is not managed in Git', () => {
       const result = gitWorkingTree('/', {
-        allowSubDir: false
+        options: { allowSubDir: false }
       })
 
-      expect(result).to.deep.equal({
-        failures: ['The directory is not managed with Git.']
-      })
+      expect(result[result.length - 1].message).to.equal('The directory is not managed with Git.')
     })
   })
 })


### PR DESCRIPTION
This change is another step toward getting a codeclimate-repolinter engine created. The addition of a `Result` class allows a formatter to have the additional information needed. 

- The Result class exposes:
  - The rule itself
  - The message returned by running the rule
  - The target file/directory/commit the rule was run against
  - The status of the result (success,error,warning)

Once I finished this, I realized the word `rule` is overloaded some in the code. I'm open to suggestions on how to fix that. Either in this PR, or in a separate one. Of course, I'm open to any other suggestions as well. I realize this is a rather large change.

/cc @caniszczyk, @bufferoverflow 