### PR TITLE
Adding a rule that fails if contents are found in a file

### DIFF
--- a/rules/file-not-contents.js
+++ b/rules/file-not-contents.js
@@ -12,8 +12,8 @@ module.exports = function (fileSystem, rule) {
     const fileContents = fs.getFileContents(file)
     const regexp = new RegExp(options.content, options.flags)
 
-    const passed = fileContents && fileContents.toString().search(regexp) == -1
-    const message = `File ${file} ${passed ? 'doesn\'t contain' : 'contains' } ${options.content}`
+    const passed = fileContents && fileContents.toString().search(regexp) === -1
+    const message = `File ${file} ${passed ? 'doesn\'t contain' : 'contains'} ${options.content}`
 
     return new Result(rule, message, file, passed)
   })

--- a/rules/file-not-contents.js
+++ b/rules/file-not-contents.js
@@ -1,0 +1,22 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+const Result = require('../lib/result')
+
+// TODO: This is mostly a copy and paste of file-contents.js. Ideally it would be implemented as a NOT(file-contents.js)
+module.exports = function (fileSystem, rule) {
+  const options = rule.options
+  const fs = options.fs || fileSystem
+  const files = fs.findAll(options.files)
+
+  const results = files.map(file => {
+    const fileContents = fs.getFileContents(file)
+    const regexp = new RegExp(options.content, options.flags)
+
+    const passed = fileContents && fileContents.toString().search(regexp) == -1
+    const message = `File ${file} ${passed ? 'doesn\'t contain' : 'contains' } ${options.content}`
+
+    return new Result(rule, message, file, passed)
+  })
+
+  return results
+}

--- a/tests/rules/file_not_contents_tests.js
+++ b/tests/rules/file_not_contents_tests.js
@@ -1,0 +1,95 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const chai = require('chai')
+const expect = chai.expect
+const Result = require('../../lib/result')
+
+describe('rule', () => {
+  describe('files_not_contents', () => {
+    const fileContents = require('../../rules/file-not-contents')
+
+    it('returns passes if requested file contents do not exist', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return ['README.md']
+            },
+            getFileContents () {
+              return 'foo'
+            },
+            targetDir: '.'
+          },
+          files: ['README*'],
+          content: 'bar'
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'File README.md doesn\'t contain bar',
+            'README.md',
+            true
+          )
+      ]
+
+      const actual = fileContents(null, rule)
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns fails if requested file contents exists', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return ['README.md']
+            },
+            getFileContents () {
+              return 'foo'
+            },
+            targetDir: '.'
+          },
+          files: ['README*'],
+          content: 'foo'
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'File README.md contains foo',
+            'README.md',
+            false
+          )
+      ]
+
+      const actual = fileContents(null, rule)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns nothing if requested file does not exist', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return []
+            },
+            getFileContents () {
+
+            },
+            targetDir: '.'
+          },
+          file: 'README.md',
+          content: 'foo'
+        }
+      }
+
+      const actual = fileContents(null, rule)
+      const expected = []
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #58. Apologies for the c+p of file-contents. Feels like #21 would be needed to stop the c+p.