### PR TITLE
fix: make license-headers-exist reuse.software compatible

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -10,7 +10,7 @@
       "license-detectable-by-licensee": ["error"],
       "test-directory-exists:directory-existence": ["error", {"directories": ["test*", "specs"]}],
       "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml"]}],
-      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "All rights reserved", "Licensed under"]}]
+      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"]}]
     },
     "javascript": {
       "package-metadata-exists:file-existence": ["error", {"files": ["package.json"]}]


### PR DESCRIPTION
The http://reuse.software/ initiative driven by fsfe provides best practices for license headers and SPDX usage. Some of those best practices are also adopted within Linux Kernel. This change modifies the  license-headers-exist rule so that projects following the reuse.software guidelines do pass when executing repolinter, see https://git.fsfe.org/reuse/simple-hello/src/branch/master/src/server.js as an example.
