### PR TITLE
Chore/apply reuse software

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ This rule requires ```licensee``` in the path, see [command line dependencies](#
 
 ## License
 
-This project is licensed under the [Apache 2.0](LICENSE) license.
+This project is licensed under the [Apache 2.0](LICENSE) license using http://reuse.software best practice.

--- a/README.md.license
+++ b/README.md.license
@@ -1,0 +1,2 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0

--- a/bin/repolinter.js
+++ b/bin/repolinter.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const path = require('path')
 const repolinter = require('..')

--- a/formatters/json_formatter.js
+++ b/formatters/json_formatter.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 class JsonFormatter {
   format (result) {

--- a/formatters/symbol_formatter.js
+++ b/formatters/symbol_formatter.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const logSymbols = require('log-symbols')
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const jsonfile = require('jsonfile')
 const path = require('path')

--- a/lib/file_system.js
+++ b/lib/file_system.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const path = require('path')
 const glob = require('matched')

--- a/lib/linguist.js
+++ b/lib/linguist.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const spawnSync = require('child_process').spawnSync
 

--- a/lib/result.js
+++ b/lib/result.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const symbolFormatter = require('../formatters/symbol_formatter')
 const jsonFormatter = require('../formatters/json_formatter')

--- a/rules/directory-existence.js
+++ b/rules/directory-existence.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const fileExistence = require('./file-existence')
 module.exports = function (fileSystem, rule) {

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -1,5 +1,6 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+
 const Result = require('../lib/result')
 
 module.exports = function (fileSystem, rule) {

--- a/rules/file-existence.js
+++ b/rules/file-existence.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const Result = require('../lib/result')
 

--- a/rules/file-starts-with.js
+++ b/rules/file-starts-with.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const Result = require('../lib/result')
 

--- a/rules/file-type-exclusion.js
+++ b/rules/file-type-exclusion.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const Result = require('../lib/result')
 

--- a/rules/git-grep-commits.js
+++ b/rules/git-grep-commits.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const spawnSync = require('child_process').spawnSync
 const Result = require('../lib/result')

--- a/rules/git-grep-log.js
+++ b/rules/git-grep-log.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const spawnSync = require('child_process').spawnSync
 const Result = require('../lib/result')

--- a/rules/git-list-tree.js
+++ b/rules/git-list-tree.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const spawnSync = require('child_process').spawnSync
 const Result = require('../lib/result')

--- a/rules/git-working-tree.js
+++ b/rules/git-working-tree.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const spawnSync = require('child_process').spawnSync
 const Result = require('../lib/result')

--- a/rules/license-detectable-by-licensee.js
+++ b/rules/license-detectable-by-licensee.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const isWindows = require('is-windows')
 const spawnSync = require('child_process').spawnSync

--- a/tests/formatters/json_formatter_tests.js
+++ b/tests/formatters/json_formatter_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/formatters/symbol_formatter_tests.js
+++ b/tests/formatters/symbol_formatter_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/lib/file_system_tests.js
+++ b/tests/lib/file_system_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const path = require('path')
 const chai = require('chai')

--- a/tests/package/repolinter_tests.js
+++ b/tests/package/repolinter_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const path = require('path')
 const chai = require('chai')

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/rules/file_existence_tests.js
+++ b/tests/rules/file_existence_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/rules/file_starts_with_tests.js
+++ b/tests/rules/file_starts_with_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect
@@ -15,7 +15,7 @@ describe('rule', () => {
         options: {
           files: ['rules/file-starts-with.js'],
           lineCount: 2,
-          patterns: ['Copyright', 'All rights reserved', 'Licensed under']
+          patterns: ['Copyright', 'License']
         }
       }
 

--- a/tests/rules/file_type_exclusion_tests.js
+++ b/tests/rules/file_type_exclusion_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/rules/git_grep_commits_tests.js
+++ b/tests/rules/git_grep_commits_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/rules/git_grep_log_tests.js
+++ b/tests/rules/git_grep_log_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/rules/git_list_tree_tests.js
+++ b/tests/rules/git_list_tree_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect

--- a/tests/rules/git_working_tree_tests.js
+++ b/tests/rules/git_working_tree_tests.js
@@ -1,5 +1,5 @@
 // Copyright 2017 TODO Group. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
 
 const chai = require('chai')
 const expect = chai.expect


### PR DESCRIPTION
This PR is based on #63 and does change the license headers according to the https://reuse.software/ guidelines. I would appreciate every feedback on this, especially to talk with the reuse initiative on ways to improve further to simplify and automate license compliance. 