### PR TITLE
Adding Axioms - migrating linguist/adding licensee

### DIFF
--- a/axioms/licensee.js
+++ b/axioms/licensee.js
@@ -1,0 +1,14 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const licensee = require('../lib/licensee')
+module.exports = function (targetDir) {
+  let licenses = []
+  try {
+    licenses = licensee.identifyLicensesSync(targetDir)
+  } catch (error) {
+    console.log(`Licensee Axiom: Licensee not found in path, only running license-independent rules`)
+    console.log(error)
+  }
+  return licenses
+}

--- a/axioms/linguist.js
+++ b/axioms/linguist.js
@@ -1,0 +1,13 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const linguist = require('../lib/linguist')
+module.exports = function (targetDir) {
+  let languages = []
+  try {
+    languages = linguist.identifyLanguagesSync(targetDir).map(language => language.toLowerCase())
+  } catch (error) {
+    console.log(`Linguist Axiom: Linguist not found in path, only running language-independent rules`)
+  }
+  return languages
+}

--- a/lib/licensee.js
+++ b/lib/licensee.js
@@ -1,0 +1,27 @@
+// Copyright 2018 TODO Group. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+const isWindows = require('is-windows')
+const spawnSync = require('child_process').spawnSync
+
+class Licensee {
+  /**
+   * Returns the license found for the project.
+   * Currently it only identifies one license, but the API intent is to support multiple licenses being found.
+   * Associate Array of license String to Array of SPDX License identifiers
+   *
+   * Throws 'Licensee not installed' error if command line of 'licensee' is not available.
+   */
+  identifyLicensesSync (targetDir) {
+    const licenseeOutput = spawnSync(isWindows() ? 'licensee.bat' : 'licensee', [targetDir]).stdout
+    if (licenseeOutput == null) {
+      throw new Error('Licensee not installed')
+    }
+
+    const expected = /License: ([^\n]+)/
+    const license = licenseeOutput.toString().match(expected)
+    return [license[1]]
+  }
+}
+
+module.exports = new Licensee()

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -1,4 +1,8 @@
 {
+  "axioms": {
+    "linguist":"language",
+    "licensee":"license"
+  },
   "rules": {
     "all": {
       "license-file-exists:file-existence": ["error", {"files": ["LICENSE*", "COPYING*"]}],
@@ -12,17 +16,20 @@
       "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml"]}],
       "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "All rights reserved", "Licensed under"]}]
     },
-    "javascript": {
+    "language=javascript": {
       "package-metadata-exists:file-existence": ["error", {"files": ["package.json"]}]
     },
-    "ruby": {
+    "language=ruby": {
       "package-metadata-exists:file-existence": ["error", {"files": ["Gemfile"]}]
     },
-    "java": {
+    "language=java": {
       "package-metadata-exists:file-existence": ["error", {"files": ["pom.xml", "build.xml", "build.gradle"]}]
     },
-    "python": {
+    "language=python": {
       "package-metadata-exists:file-existence": ["error", {"files": ["requirements.txt"]}]
+    },
+    "license=Apache License 2.0": {
+      "notice-file-exists:file-existence": ["error", {"files": ["NOTICE*"]}]
     }
   }
 }


### PR DESCRIPTION
It breaks one of the tests; not sure why the test is testing this.

  1) rule git_grep_commits fails if the blacklist pattern matches a commit:
     AssertionError: expected '(axioms/licensee.js) contains blacklisted words in commit 7a7f9d7.\n\tBlacklist: Copyright 2017 TODO Group\\. All rights reserved\\.' to match /\(bin\/repolinter\.js\) contains blacklisted words in commit \w{7}, and \d+ more commits\./
      at Context.it (tests/rules/git_grep_commits_tests.js:48:36)