### PR TITLE
Recognize setup.py as Python package metadata

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -22,7 +22,7 @@
       "package-metadata-exists:file-existence": ["error", {"files": ["pom.xml", "build.xml", "build.gradle"]}]
     },
     "python": {
-      "package-metadata-exists:file-existence": ["error", {"files": ["requirements.txt"]}]
+      "package-metadata-exists:file-existence": ["error", {"files": ["setup.py", "requirements.txt"]}]
     }
   }
 }


### PR DESCRIPTION
`setup.py` is the standard Python setuptools packaging file. It will
likely exist more often than `requirements.txt` (which specifies the
project's package dependencies) because the latter might not exist if
the project has no dependencies.