### PR TITLE
Add objective-c and swift package metadata file patterns

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -23,6 +23,9 @@
     },
     "python": {
       "package-metadata-exists:file-existence": ["error", {"files": ["setup.py", "requirements.txt"]}]
+    },
+    "objective-c": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["Cartfile", "Podfile", "*.podspec"]}]
     }
   }
 }

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -26,6 +26,9 @@
     },
     "objective-c": {
       "package-metadata-exists:file-existence": ["error", {"files": ["Cartfile", "Podfile", "*.podspec"]}]
+    },
+    "swift": {
+      "package-metadata-exists:file-existence": ["error", {"files": ["Package.swift"]}]
     }
   }
 }


### PR DESCRIPTION
`Cartfile` is used by the [Carthage](https://github.com/Carthage/Carthage) dependency manager.

`Podfile` and `*.podspec` are used by the [CocoaPods](https://cocoapods.org/) dependency manager.

`Package.swift` is used by the [Swift Package Manager](https://swift.org/package-manager/).