### PR TITLE
PR#29: Check Code of Conduct for Email Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The rules system is made up of rule types which can be customized to fit your ne
 Fails if none of the directories specified in the ```directories``` option exist.
 
 ### file-contents
-Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option. If the content is a regular express or some other non-human-readable string, include the ```human-readable-content``` option with human-readable output.
+Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option. If the content is a regular expression or some other non-human-readable string, include the ```human-readable-content``` option with human-readable output.
 
 ### file-existence
 Fails if none of the files specified in the ```files``` option exist.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Fails if there isn't a file matching ```CONTRIB*``` in the root of the target di
 ### code-of-conduct-file-exists
 Fails if there isn't a file matching ```CODEOFCONDUCT*```, ```CODE-OF-CONDUCT*``` or ```CODE_OF_CONDUCT*``` in the root of the target directory.
 
+### code-of-conduct-file-contains-email
+Fails of the code of conduct file does not contain an email address.
+
 ### readme-references-license
 Fails if the files matching ```README*``` doesn't match the regular expression ```license```.
 
@@ -146,7 +149,7 @@ The rules system is made up of rule types which can be customized to fit your ne
 Fails if none of the directories specified in the ```directories``` option exist.
 
 ### file-contents
-Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option.
+Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option. If the content is a regular express or some other non-human-readable string, include the ```human-readable-content``` option with human-readable output.
 
 ### file-existence
 Fails if none of the files specified in the ```files``` option exist.

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -12,10 +12,14 @@ module.exports = function (fileSystem, rule) {
     const regexp = new RegExp(options.content, options.flags)
 
     const passed = fileContents && fileContents.toString().search(regexp) !== -1
-    const message = `File ${file} ${passed ? 'contains' : 'doesn\'t contain'} ${options.content}`
+    const message = `File ${file} ${passed ? 'contains' : 'doesn\'t contain'} ${getContent()}`
 
     return new Result(rule, message, file, passed)
   })
+
+  function getContent () {
+    return options['human-readable-content'] !== undefined ? options['human-readable-content'] : options.content
+  }
 
   return results
 }

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -10,7 +10,16 @@
       "license-detectable-by-licensee": ["error"],
       "test-directory-exists:directory-existence": ["error", {"directories": ["test*", "specs"]}],
       "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml", "Jenkinsfile"]}],
-      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"]}]
+      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"]}],
+      "code-of-conduct-file-contains-email:file-contents": [
+        "error",
+        {
+          "files": ["CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT*"],
+          "content": ".+@.+\\..+",
+          "flags": "i",
+          "human-readable-content": "email address"
+        }
+      ]
     },
     "javascript": {
       "package-metadata-exists:file-existence": ["error", {"files": ["package.json"]}]

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -39,6 +39,37 @@ describe('rule', () => {
       expect(actual).to.deep.equal(expected)
     })
 
+    it('returns passes if requested file contents exists with human-readable contents', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return ['README.md']
+            },
+            getFileContents () {
+              return 'foo'
+            },
+            targetDir: '.'
+          },
+          files: ['README*'],
+          content: '[abcdef][oO0][^q]',
+          'human-readable-content': 'actually foo'
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'File README.md contains actually foo',
+            'README.md',
+            true
+          )
+      ]
+
+      const actual = fileContents(null, rule)
+      expect(actual).to.deep.equal(expected)
+    })
+
     it('returns fails if requested file contents does not exist', () => {
       const rule = {
         options: {

--- a/tests/rules/git_grep_commits_tests.js
+++ b/tests/rules/git_grep_commits_tests.js
@@ -45,7 +45,7 @@ describe('rule', () => {
       }
 
       const actual = gitGrepCommits(new FileSystem(), rule)
-      expect(actual[0].message).to.match(new RegExp(/\(bin\/repolinter\.js\) contains blacklisted words in commit \w{7}, and \d+ more commits\./))
+      expect(actual[0].message).to.match(new RegExp(/ contains blacklisted words in commit \w{7}, and \d+ more commits\./))
       expect(actual[0].data.file.commits[0].lines[0]).to.match(new RegExp(DIFF_CORRECT_CASE))
       expect(actual[0].passed).to.equal(false)
     })


### PR DESCRIPTION
This ensures there is an email address in the code of conduct file.

This also extends the file-contents functionality to have a
human-readable contents for those cases where the contents you are
searching for is not human-readable, like a regexp.

Updated README to reflect the changes.

Fixed an overly-strict git grep commits test.