### PR TITLE
Add option to ignore case for file-starts-with rule

### DIFF
--- a/rules/file-starts-with.js
+++ b/rules/file-starts-with.js
@@ -11,7 +11,10 @@ module.exports = function (fileSystem, rule) {
   let results = []
   files.forEach(file => {
     const lines = fs.readLines(file, options.lineCount)
-    const misses = options.patterns.filter(pattern => !lines.match(pattern))
+    const misses = options.patterns.filter((pattern) => {
+      const regexp = new RegExp(pattern, options.flags)
+      return !lines.match(regexp)
+    })
 
     let message = `The first ${options.lineCount} lines of '${file}'`
     const passed = misses.length === 0

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -14,7 +14,7 @@
       "license-detectable-by-licensee": ["error"],
       "test-directory-exists:directory-existence": ["error", {"directories": ["test*", "specs"]}],
       "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml", "Jenkinsfile"]}],
-      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"]}]
+      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"], "flags": "i"}]
     },
     "language=javascript": {
       "package-metadata-exists:file-existence": ["error", {"files": ["package.json"]}]


### PR DESCRIPTION
I was testing on a few of our projects and noticed `source-license-headers-exist` failures because in our headers we use "LICENSE" vs. "License". This PR is to make the `file-starts-with` rule optionally case insensitive for the patterns passed in.

Test:

```
$ bin/repolinter.js --git https://github.com/facebook/docusaurus
```

Previously this had errors like:

```
⚠ source-license-headers-exist: The first 5 lines of 'website/pages/en/help.js' do not contain the patterns:
	License
```

Now this passes:

```
✔ source-license-headers-exist: The first 5 lines of 'website/pages/en/help.js' contain all of the requested patterns.
```