### PR TITLE
PR#65: Adding NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+TODO Group Repo Linter
+Copyright 2017-2018 TODO Group
+
+This product includes software developed at
+TODO Group (http://todogroup.org/).

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Fails if none of the directories specified in the ```directories``` option exist
 Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option.
 
 ### file-existence
-Fails if none of the files specified in the ```files``` option exist.
+Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user.
 
 ### file-not-contents
 The opposite of ```file-contents```.

--- a/rules/file-existence.js
+++ b/rules/file-existence.js
@@ -13,7 +13,7 @@ module.exports = function (fileSystem, rule) {
     if (passed) {
       return `found (${file})`
     } else {
-      return `not found: (${options.files.join(', ')})`
+      return `not found: (${options.files.join(', ')})${options['fail-message'] !== undefined ? ' ' + options['fail-message'] : ''}`
     }
   })()
 

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -26,7 +26,13 @@
       "package-metadata-exists:file-existence": ["error", {"files": ["pom.xml", "build.xml", "build.gradle"]}]
     },
     "license=Apache License 2.0": {
-      "notice-file-exists:file-existence": ["error", {"files": ["NOTICE*"]}]
+      "notice-file-exists:file-existence": [
+        "error",
+        {
+          "files": ["NOTICE*"],
+          "fail-message": "The NOTICE file is described in section 4.4 of the Apache License version 2.0. Its presence is not mandated by the license itself, but by ASF policy."
+        }
+      ]
     },
     "language=python": {
       "package-metadata-exists:file-existence": ["error", {"files": ["setup.py", "requirements.txt"]}]

--- a/tests/rules/file_existence_tests.js
+++ b/tests/rules/file_existence_tests.js
@@ -63,5 +63,33 @@ describe('rule', () => {
 
       expect(actual).to.deep.equal(expected)
     })
+
+    it('returns a failure result if requested file doesn\'t exist with a failure message', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirst () {
+            },
+            targetDir: '.'
+          },
+          files: ['LICENSE*'],
+          name: 'License file',
+          'fail-message': 'The license file should exist.'
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'not found: (LICENSE*) The license file should exist.',
+            null,
+            false
+          )
+      ]
+
+      const actual = fileExistence(null, rule)
+
+      expect(actual).to.deep.equal(expected)
+    })
   })
 })


### PR DESCRIPTION
This also extends the file-exists rule to have a fail-message to further
explain why a file should be there.