### PR TITLE
Fixing PR #67: Add nocase option for files & dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Fails if there isn't a file supporting a Continuous Integration tool, matching `
 Produces a failure for each file matching ```**/*.js,!node_modules/**``` option if the first 5 lines don't match all the patterns ```copyright```, ```all rights reserved```, and ```licensed under```.
 
 ### test-directory-exists
-Fails if there isn't a directory matching ```test*``` or ```specs``` in the root of the target directory.
+Fails if there isn't a directory matching ```test*``` or ```specs``` in the directory tree of the target directory.
 
 
 ## Configuring rules
@@ -146,13 +146,13 @@ Rules can be configured to only run if the repository contains a specific langua
 The rules system is made up of rule types which can be customized to fit your needs.
 
 ### directory-existence
-Fails if none of the directories specified in the ```directories``` option exist.
+Fails if none of the directories specified in the ```directories``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": "true"``` in the options for a case-insensitive search.
 
 ### file-contents
 Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option. If the content is a regular expression or some other non-human-readable string, include the ```human-readable-content``` option with human-readable output.
 
 ### file-existence
-Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user.
+Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": "true"``` in the options for a case-insensitive search.
 
 ### file-not-contents
 The opposite of ```file-contents```.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Rules can be configured to only run if the repository contains a specific langua
 The rules system is made up of rule types which can be customized to fit your needs.
 
 ### directory-existence
-Fails if none of the directories specified in the ```directories``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": "true"``` in the options for a case-insensitive search.
+Fails if none of the directories specified in the ```directories``` option exist. Pass in a ```fail-message``` option to further explain why the directory should exist to the user. Pass in ```"nocase": "true"``` in the options for a case-insensitive search.
 
 ### file-contents
 Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option. If the content is a regular expression or some other non-human-readable string, include the ```human-readable-content``` option with human-readable output.

--- a/lib/file_system.js
+++ b/lib/file_system.js
@@ -26,8 +26,8 @@ class FileSystem {
     }
   }
 
-  findAll (globs) {
-    return glob.sync(globs, {cwd: this.targetDir})
+  findAll (globs, nocase) {
+    return glob.sync(globs, {cwd: this.targetDir, nocase: nocase})
       .filter(relativePath => this.shouldInclude(relativePath))
   }
 

--- a/rules/file-existence.js
+++ b/rules/file-existence.js
@@ -6,7 +6,7 @@ const Result = require('../lib/result')
 module.exports = function (fileSystem, rule) {
   const options = rule.options
   const fs = options.fs || fileSystem
-  const file = fs.findFirst(options.files)
+  const file = fs.findFirst(options.files, options.nocase === 'true')
 
   const passed = !!file
   const message = (() => {

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -12,7 +12,7 @@
       "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll"]}],
       "license-detectable-by-licensee": ["error"],
-      "test-directory-exists:directory-existence": ["error", {"directories": ["test*", "specs"]}],
+      "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": "true"}],
       "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml", "Jenkinsfile"]}],
       "code-of-conduct-file-contains-email:file-contents": [
         "error",

--- a/tests/lib/file_system_tests.js
+++ b/tests/lib/file_system_tests.js
@@ -38,6 +38,36 @@ describe('lib', () => {
         })
         expect(files).to.deep.equal(includedFiles)
       })
+
+      it('should honor nocase true', () => {
+        const includedFiles = ['index.js']
+        const fs = new FileSystem(path.resolve('.'), includedFiles)
+
+        const files = fs.findAll('**/iNdEx.Js', true).map(file => {
+          return path.relative(path.resolve('.'), file)
+        })
+        expect(files).to.deep.equal(includedFiles)
+      })
+
+      it('should honor nocase false', () => {
+        const includedFiles = ['index.js']
+        const fs = new FileSystem(path.resolve('.'), includedFiles)
+
+        const files = fs.findAll('**/iNdEx.Js', false).map(file => {
+          return path.relative(path.resolve('.'), file)
+        })
+        expect(files).to.deep.equal([])
+      })
+
+      it('should not honor nocase by default', () => {
+        const includedFiles = ['index.js']
+        const fs = new FileSystem(path.resolve('.'), includedFiles)
+
+        const files = fs.findAll('**/iNdEx.Js').map(file => {
+          return path.relative(path.resolve('.'), file)
+        })
+        expect(files).to.deep.equal([])
+      })
     })
   })
 })

--- a/tests/rules/file_existence_tests.js
+++ b/tests/rules/file_existence_tests.js
@@ -37,6 +37,36 @@ describe('rule', () => {
       expect(actual).to.deep.equal(expected)
     })
 
+    it('returns a passed result if requested file exists case-insensitivly', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirst (dontcare, nocase) {
+              expect(nocase).to.equal(true)
+              return 'LICENSE.md'
+            },
+            targetDir: '.'
+          },
+          files: ['lIcEnSe*'],
+          name: 'License file',
+          nocase: 'true'
+        }
+      }
+
+      const expected = [
+        new Result(
+            rule,
+            'found (LICENSE.md)',
+            'LICENSE.md',
+            true
+          )
+      ]
+
+      const actual = fileExistence(null, rule)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
     it('returns a failure result if requested file doesn\'t exist', () => {
       const rule = {
         options: {


### PR DESCRIPTION
This allows an option to be passed into the file-exists and
directory-exists  rules to allow for case-insensitive searches.

This also makes the test directory deeply embedable by default.

README updated with the changes and tests added.