### PR TITLE
PR #25: Added npx details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To run against a git repository, use the `--git` option: `npx repolinter --git h
 
 Note, if you are running a version of npm < 5.2.0, run `npm install npx` first.
 
+You can also run Repo Linter locally by cloning this repository and running `bin/repolinter.js` with either a directory of a git repository the same as above. This is useful during development.
+
 ## Examples
 
 To quickly get started, checkout this repository and run `npx repolinter` against itself.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@ Lint open source repositories for common issues.
 
 ## Usage
 
-To run against a directory, add it to the command line `bin/repolinter.js /my/code/dir`.
+To run against a directory, add it to the command line `npx repolinter /my/code/dir`.
 
-To run against a git repository, use the `--git` option: `bin/repolinter.js --git https://my.git.code/awesome`.
+To run against a git repository, use the `--git` option: `npx repolinter --git https://my.git.code/awesome`.
+
+Note, if you are running a version of npm < 5.2.0, run `npm install npx` first.
 
 ## Examples
 
-To quickly get started, checkout this repository and run `repolinter` against itself.
+To quickly get started, checkout this repository and run `npx repolinter` against itself.
 
 ```
 git clone https://github.com/todogroup/repolinter
-bin/repolinter.js
+npx repolinter
 ✔ license-file-exists: found (LICENSE)
 ✔ readme-file-exists: found (README.md)
 ✔ contributing-file-exists: found (CONTRIBUTING)


### PR DESCRIPTION
With npx, we can now run repolinter without checking out the code as
long as npm >= 5.2.0 is installed, or npx itself is installed (for
earlier versions of npm.