### PR TITLE
Add CI check for Circle CI 2.0 config file

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -13,7 +13,7 @@
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll"]}],
       "license-detectable-by-licensee": ["error"],
       "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": "true"}],
-      "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml", "Jenkinsfile"]}],
+      "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile"]}],
       "code-of-conduct-file-contains-email:file-contents": [
         "error",
         {


### PR DESCRIPTION
According to [Circle CI docs](https://circleci.com/docs/2.0/#adding-a-yml-file), the config file for v2.0 is in a different place. This PR aims to add this check.

Test:

```
bin/repolinter.js --git https://github.com/facebook/Docusaurus
```

Before the change, this resulted in:

```
...
✔ license-detectable-by-licensee: Licensee identified the license for project: MIT License
✔ test-directory-exists: found (admin/testing-changes-on-Docusaurus-itself.md)
✖ integrates-with-ci: not found: (.gitlab-ci.yml, .travis.yml, appveyor.yml, circle.yml, Jenkinsfile)
...
```

After the change, I see:

```
...
✔ license-detectable-by-licensee: Licensee identified the license for project: MIT License
✔ test-directory-exists: found (admin/testing-changes-on-Docusaurus-itself.md)
✔ integrates-with-ci: found (.circleci/config.yml)
...
```