### PR TITLE
returning scan result as an object and adding ruleset to the signature of lint function.

### DIFF
--- a/bin/repolinter.js
+++ b/bin/repolinter.js
@@ -13,7 +13,7 @@ if (process.argv[2] === '--git') {
 
   git.clone(process.argv[3], tmpDir, (error) => {
     if (!error) {
-      repolinter.lint(tmpDir)
+      repolinter.lint(tmpDir);
     }
     rimraf(tmpDir, function () {})
   })

--- a/bin/repolinter.js
+++ b/bin/repolinter.js
@@ -13,7 +13,7 @@ if (process.argv[2] === '--git') {
 
   git.clone(process.argv[3], tmpDir, (error) => {
     if (!error) {
-      repolinter.lint(tmpDir);
+      repolinter.lint(tmpDir)
     }
     rimraf(tmpDir, function () {})
   })

--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
             anyFailures = anyFailures || results.some(result => !result.passed && result.rule.level === 'error')
           } catch (error) {
             results.push(new Result(rule, error.message, null, false))
+            evaluation.push(results);
           }
         }
       })
@@ -77,7 +78,9 @@ module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
     renderResults(singleResult.filter(result => result.passed))
   });
 
-  if (anyFailures) process.exitCode = 1;
+  if (anyFailures) {
+    process.exitCode = 1
+  }
 
   return evaluation;
 
@@ -134,5 +137,3 @@ module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
     return 'error'
   }
 }
-
-

--- a/index.js
+++ b/index.js
@@ -23,12 +23,12 @@ module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
     fileSystem.filterPaths = filterPaths
   }
 
-  if (!ruleset){
+  if (!ruleset) {
     let rulesetPath = findConfig('repolint.json', {cwd: targetDir})
     rulesetPath = rulesetPath || findConfig('repolinter.json', {cwd: targetDir})
     rulesetPath = rulesetPath || path.join(__dirname, 'rulesets/default.json')
     exports.outputInfo(`Ruleset: ${path.relative(targetDir, rulesetPath)}`)
-    ruleset = jsonfile.readFileSync(rulesetPath);
+    ruleset = jsonfile.readFileSync(rulesetPath)
   }
   let targets = ['all']
 
@@ -45,9 +45,9 @@ module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
 
   let anyFailures = false
   // Execute all rule targets
-  
+
   // global variable for return statement
-  let evaluation = new Array();
+  let evaluation = []
   targets.forEach(target => {
     const targetRules = ruleset.rules[target]
     if (targetRules) {
@@ -58,31 +58,31 @@ module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
         rule.module = ruleIdParts.length === 2 ? ruleIdParts[1] : ruleIdParts[0]
         if (rule.enabled) {
           // TODO: Do something more secure
-          let results = new Array();
+          let results = []
           try {
             const ruleFunction = require(path.join(__dirname, 'rules', rule.module))
             results = ruleFunction(fileSystem, rule)
-            evaluation.push(results);
+            evaluation.push(results)
             anyFailures = anyFailures || results.some(result => !result.passed && result.rule.level === 'error')
           } catch (error) {
             results.push(new Result(rule, error.message, null, false))
-            evaluation.push(results);
+            evaluation.push(results)
           }
         }
       })
     }
-  });
+  })
 
-  evaluation.forEach(singleResult =>{
+  evaluation.forEach(singleResult => {
     renderResults(singleResult.filter(result => !result.passed))
     renderResults(singleResult.filter(result => result.passed))
-  });
+  })
 
   if (anyFailures) {
     process.exitCode = 1
   }
 
-  return evaluation;
+  return evaluation
 
   function renderResults (results) {
     formatResults(results).filter(x => !!x).forEach(renderResult)

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports.resultFormatter = exports.defaultFormatter
 module.exports.outputInfo = console.log
 module.exports.outputResult = console.log
 
-module.exports.lint = function (targetDir, filterPaths = []) {
+module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
   fileSystem.targetDir = targetDir
   exports.outputInfo(`Target directory: ${targetDir}`)
   if (filterPaths.length > 0) {
@@ -23,13 +23,13 @@ module.exports.lint = function (targetDir, filterPaths = []) {
     fileSystem.filterPaths = filterPaths
   }
 
-  let rulesetPath = findConfig('repolint.json', {cwd: targetDir})
-  rulesetPath = rulesetPath || findConfig('repolinter.json', {cwd: targetDir})
-  rulesetPath = rulesetPath || path.join(__dirname, 'rulesets/default.json')
-
-  exports.outputInfo(`Ruleset: ${path.relative(targetDir, rulesetPath)}`)
-  const ruleset = jsonfile.readFileSync(rulesetPath)
-
+  if (!ruleset){
+    let rulesetPath = findConfig('repolint.json', {cwd: targetDir})
+    rulesetPath = rulesetPath || findConfig('repolinter.json', {cwd: targetDir})
+    rulesetPath = rulesetPath || path.join(__dirname, 'rulesets/default.json')
+    exports.outputInfo(`Ruleset: ${path.relative(targetDir, rulesetPath)}`)
+    ruleset = jsonfile.readFileSync(rulesetPath);
+  }
   let targets = ['all']
 
   // Identify axioms and execute them
@@ -46,7 +46,7 @@ module.exports.lint = function (targetDir, filterPaths = []) {
   let anyFailures = false
   // Execute all rule targets
   
-  // global variable for return statement 
+  // global variable for return statement
   let evaluation = new Array();
   targets.forEach(target => {
     const targetRules = ruleset.rules[target]
@@ -134,3 +134,5 @@ module.exports.lint = function (targetDir, filterPaths = []) {
     return 'error'
   }
 }
+
+

--- a/rules/git-grep-commits.js
+++ b/rules/git-grep-commits.js
@@ -11,7 +11,7 @@ function listCommitsWithLines (fileSystem, options) {
     return {
       hash: commit,
       lines: gitLinesAtCommit(fileSystem.targetDir, pattern, options.ignoreCase, commit)
-               .filter(line => fileSystem.shouldInclude(line.path))
+        .filter(line => fileSystem.shouldInclude(line.path))
     }
   }).filter(commit => commit.lines.length > 0)
 }
@@ -28,10 +28,10 @@ function gitGrep (targetDir, pattern, ignoreCase, commit) {
 
 function gitLinesAtCommit (targetDir, pattern, ignoreCase, commit) {
   const lines = gitGrep(targetDir, pattern, ignoreCase, commit)
-                  .map((entry) => {
-                    const [path, ...rest] = entry.substring(commit.length + 1).split(':')
-                    return { path: path, content: rest.join(':') }
-                  })
+    .map((entry) => {
+      const [path, ...rest] = entry.substring(commit.length + 1).split(':')
+      return { path: path, content: rest.join(':') }
+    })
 
   return lines
 }

--- a/rules/git-list-tree.js
+++ b/rules/git-list-tree.js
@@ -21,8 +21,8 @@ function listFiles (fileSystem, options) {
   const commits = gitAllCommits(fileSystem.targetDir)
   commits.forEach((commit) => {
     const includedFiles = gitFilesAtCommit(fileSystem.targetDir, commit)
-                          .filter(file => file.match(pattern))
-                          .filter(file => fileSystem.shouldInclude(file))
+      .filter(file => file.match(pattern))
+      .filter(file => fileSystem.shouldInclude(file))
     includedFiles.forEach(path => {
       const existingFile = files.find(f => f.path === path)
       if (existingFile) {

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -28,11 +28,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'File README.md contains foo',
-            'README.md',
-            true
-          )
+          rule,
+          'File README.md contains foo',
+          'README.md',
+          true
+        )
       ]
 
       const actual = fileContents(null, rule)
@@ -59,11 +59,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'File README.md contains actually foo',
-            'README.md',
-            true
-          )
+          rule,
+          'File README.md contains actually foo',
+          'README.md',
+          true
+        )
       ]
 
       const actual = fileContents(null, rule)
@@ -89,11 +89,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'File README.md doesn\'t contain bar',
-            'README.md',
-            false
-          )
+          rule,
+          'File README.md doesn\'t contain bar',
+          'README.md',
+          false
+        )
       ]
 
       const actual = fileContents(null, rule)

--- a/tests/rules/file_existence_tests.js
+++ b/tests/rules/file_existence_tests.js
@@ -25,11 +25,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'found (LICENSE.md)',
-            'LICENSE.md',
-            true
-          )
+          rule,
+          'found (LICENSE.md)',
+          'LICENSE.md',
+          true
+        )
       ]
 
       const actual = fileExistence(null, rule)
@@ -55,11 +55,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'found (LICENSE.md)',
-            'LICENSE.md',
-            true
-          )
+          rule,
+          'found (LICENSE.md)',
+          'LICENSE.md',
+          true
+        )
       ]
 
       const actual = fileExistence(null, rule)
@@ -82,11 +82,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'not found: (LICENSE*)',
-            null,
-            false
-          )
+          rule,
+          'not found: (LICENSE*)',
+          null,
+          false
+        )
       ]
 
       const actual = fileExistence(null, rule)
@@ -110,11 +110,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'not found: (LICENSE*) The license file should exist.',
-            null,
-            false
-          )
+          rule,
+          'not found: (LICENSE*) The license file should exist.',
+          null,
+          false
+        )
       ]
 
       const actual = fileExistence(null, rule)

--- a/tests/rules/file_not_contents_tests.js
+++ b/tests/rules/file_not_contents_tests.js
@@ -28,11 +28,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'File README.md doesn\'t contain bar',
-            'README.md',
-            true
-          )
+          rule,
+          'File README.md doesn\'t contain bar',
+          'README.md',
+          true
+        )
       ]
 
       const actual = fileContents(null, rule)
@@ -58,11 +58,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'File README.md contains foo',
-            'README.md',
-            false
-          )
+          rule,
+          'File README.md contains foo',
+          'README.md',
+          false
+        )
       ]
 
       const actual = fileContents(null, rule)

--- a/tests/rules/file_starts_with_tests.js
+++ b/tests/rules/file_starts_with_tests.js
@@ -51,11 +51,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            `The first 5 lines of 'somefile.js' do not contain the patterns:\n\tCopyright\n\tRights`,
-            'somefile.js',
-            false
-          )
+          rule,
+          `The first 5 lines of 'somefile.js' do not contain the patterns:\n\tCopyright\n\tRights`,
+          'somefile.js',
+          false
+        )
       ]
 
       const actual = fileStartsWith(null, rule)

--- a/tests/rules/file_type_exclusion_tests.js
+++ b/tests/rules/file_type_exclusion_tests.js
@@ -24,11 +24,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'Excluded file type doesn\'t exist (*.dll)',
-            null,
-            true
-          )
+          rule,
+          'Excluded file type doesn\'t exist (*.dll)',
+          null,
+          true
+        )
       ]
       const actual = fileTypeExclusion(null, rule)
 
@@ -49,11 +49,11 @@ describe('rule', () => {
       }
       const expected = [
         new Result(
-            rule,
-            'Excluded file type exists (foo.dll)',
-            'foo.dll',
-            false
-          )
+          rule,
+          'Excluded file type exists (foo.dll)',
+          'foo.dll',
+          false
+        )
       ]
       const actual = fileTypeExclusion(null, rule)
 

--- a/tests/rules/git_grep_commits_tests.js
+++ b/tests/rules/git_grep_commits_tests.js
@@ -25,11 +25,11 @@ describe('rule', () => {
       }
       const expected = [
         new Result(
-            rule,
-            'No blacklisted words found in any commits.\n\tBlacklist: COPYRIGHT 2017 TODO GROUP\\. ALL RIGHTS RESERVED\\.',
-            null,
-            true
-          )
+          rule,
+          'No blacklisted words found in any commits.\n\tBlacklist: COPYRIGHT 2017 TODO GROUP\\. ALL RIGHTS RESERVED\\.',
+          null,
+          true
+        )
       ]
       const actual = gitGrepCommits(new FileSystem(), rule)
 

--- a/tests/rules/git_grep_log_tests.js
+++ b/tests/rules/git_grep_log_tests.js
@@ -26,11 +26,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-            rule,
-            'No blacklisted words found in any commit messages.\n\tBlacklist: THE GIT RULESET CONTAINS TWO NEW RULES THAT SEARCH THE COMMIT MESSAGES',
-            null,
-            true
-          )
+          rule,
+          'No blacklisted words found in any commit messages.\n\tBlacklist: THE GIT RULESET CONTAINS TWO NEW RULES THAT SEARCH THE COMMIT MESSAGES',
+          null,
+          true
+        )
       ]
       const actual = gitGrepLog(new FileSystem(), rule)
 

--- a/tests/rules/git_list_tree_tests.js
+++ b/tests/rules/git_list_tree_tests.js
@@ -25,11 +25,11 @@ describe('rule', () => {
 
       const expected = [
         new Result(
-           rule,
-           'No blacklisted paths found in any commits.\n\tBlacklist: rules/git-list-TREE\\.js',
-           null,
-           true
-         )
+          rule,
+          'No blacklisted paths found in any commits.\n\tBlacklist: rules/git-list-TREE\\.js',
+          null,
+          true
+        )
       ]
       const actual = gitListTree(new FileSystem(), rule)
 


### PR DESCRIPTION
The main motive of doing this is to have a freedom of using repolinter as dependency. Adding a return statement is more easy than using node's child process to monitor stdout and parse it again.

