### PR TITLE
licensee: Use the "detect" sub-command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'licensee'
+gem 'licensee', '>= 9.9.0'
 gem 'github-linguist'

--- a/lib/licensee.js
+++ b/lib/licensee.js
@@ -7,20 +7,17 @@ const spawnSync = require('child_process').spawnSync
 class Licensee {
   /**
    * Returns the license found for the project.
-   * Currently it only identifies one license, but the API intent is to support multiple licenses being found.
-   * Associate Array of license String to Array of SPDX License identifiers
    *
    * Throws 'Licensee not installed' error if command line of 'licensee' is not available.
    */
   identifyLicensesSync (targetDir) {
-    const licenseeOutput = spawnSync(isWindows() ? 'licensee.bat' : 'licensee', ['detect', targetDir]).stdout
+    const licenseeOutput = spawnSync(isWindows() ? 'licensee.bat' : 'licensee', ['detect', '--json', targetDir]).stdout
     if (licenseeOutput == null) {
       throw new Error('Licensee not installed')
     }
 
-    const expected = /License: ([^\n]+)/
-    const license = licenseeOutput.toString().match(expected)
-    return [license[1]]
+    const json = licenseeOutput.toString()
+    return JSON.parse(json).licenses.map(function (license) { return license.spdx_id })
   }
 }
 

--- a/lib/licensee.js
+++ b/lib/licensee.js
@@ -13,7 +13,7 @@ class Licensee {
    * Throws 'Licensee not installed' error if command line of 'licensee' is not available.
    */
   identifyLicensesSync (targetDir) {
-    const licenseeOutput = spawnSync(isWindows() ? 'licensee.bat' : 'licensee', [targetDir]).stdout
+    const licenseeOutput = spawnSync(isWindows() ? 'licensee.bat' : 'licensee', ['detect', targetDir]).stdout
     if (licenseeOutput == null) {
       throw new Error('Licensee not installed')
     }


### PR DESCRIPTION
As of version 9.9.0 licensee's command line usage has changed and
requires a sub-command to be specified. See

https://github.com/benbalter/licensee/releases/tag/v9.9.0