### PR TITLE
Adding wildcards to axioms (#100). 

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports.lint = function (targetDir, filterPaths = [], ruleset = null) {
       // TODO: Do something more secure
       // Execute axiom
       const axiomFunction = require(path.join(__dirname, 'axioms', axiomId))
+      targets = targets.concat(axiomName + '=*')
       targets = targets.concat(axiomFunction(targetDir).map(axiomOutput => axiomName + '=' + axiomOutput))
     })
   }

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -12,7 +12,6 @@
       "support-file-exists:file-existence": ["error", {"files": ["SUPPORT*"], "nocase": "true"}],
       "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}],
-      "license-detectable-by-licensee": ["error"],
       "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": "true"}],
       "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile"]}],
       "code-of-conduct-file-contains-email:file-contents": [
@@ -35,7 +34,10 @@
     "language=java": {
       "package-metadata-exists:file-existence": ["error", {"files": ["pom.xml", "build.xml", "build.gradle"]}]
     },
-    "license=Apache License 2.0": {
+    "license=*": {
+      "license-detectable-by-licensee": ["error"]
+    },
+    "license=Apache-2.0": {
       "notice-file-exists:file-existence": [
         "error",
         {


### PR DESCRIPTION
This, via a ruleset change, stops an error when licensee is not installed as it'll only run if the axiom succeeds. Also fixing a bug in the SPDX code in the default as that was not the correct SPDX for Apache