### PR TITLE
Drop unused dependencies, move some to dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -16,7 +16,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -33,8 +33,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -60,12 +60,12 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-union": {
@@ -79,7 +79,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -94,8 +94,8 @@
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "arrify": {
@@ -107,7 +107,8 @@
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
     },
     "async-array-reduce": {
       "version": "0.2.1",
@@ -115,14 +116,14 @@
       "integrity": "sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE="
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "balanced-match": {
@@ -135,7 +136,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -143,6 +144,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
       "dev": true
     },
     "builtin-modules": {
@@ -157,7 +164,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -170,30 +177,32 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
       "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
+      "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "check-error": "1.0.2",
-        "deep-eql": "2.0.2",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.3"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^2.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chai-string": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.4.0.tgz",
-      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk="
+      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk=",
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -206,12 +215,13 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -220,13 +230,13 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "co": {
@@ -247,7 +257,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
@@ -256,14 +266,15 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.2.11",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "contains-path": {
@@ -284,7 +295,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.23"
+        "es5-ext": "^0.10.9"
       }
     },
     "debug": {
@@ -306,14 +317,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
       "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+      "dev": true,
       "requires": {
-        "type-detect": "3.0.0"
+        "type-detect": "^3.0.0"
       },
       "dependencies": {
         "type-detect": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
-          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U="
+          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
+          "dev": true
         }
       }
     },
@@ -329,22 +342,22 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "deglob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
-      "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
+      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
       "dev": true,
       "requires": {
-        "find-root": "1.0.0",
-        "glob": "7.1.2",
-        "ignore": "3.3.3",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.6",
-        "uniq": "1.0.1"
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
       }
     },
     "del": {
@@ -353,13 +366,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "diff": {
@@ -369,34 +382,34 @@
       "dev": true
     },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2"
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -405,30 +418,31 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -437,12 +451,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -451,11 +465,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -464,8 +478,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -474,10 +488,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -491,10 +505,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.1.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -503,41 +517,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.0",
-        "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.4.3",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.3",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.8.4",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       }
     },
     "eslint-config-standard": {
@@ -547,9 +561,9 @@
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.1.tgz",
-      "integrity": "sha1-zU5GPQJo4tnnB/YfQvc/WzMzxkI=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
+      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -558,34 +572,34 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.0",
-        "object-assign": "4.1.1",
-        "resolve": "1.3.3"
+        "debug": "^2.2.0",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
       }
     },
     "eslint-module-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
-      "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -596,16 +610,16 @@
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.0",
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.2.3",
-        "eslint-module-utils": "2.0.0",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "pkg-up": "1.0.0"
+        "eslint-import-resolver-node": "^0.2.0",
+        "eslint-module-utils": "^2.0.0",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "pkg-up": "^1.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -614,22 +628,22 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         }
       }
     },
     "eslint-plugin-node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz",
-      "integrity": "sha1-gpWcqa7Xn8vSi7GxiNBcrAT7M2M=",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
+      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
       "dev": true,
       "requires": {
-        "ignore": "3.3.3",
-        "minimatch": "3.0.4",
-        "object-assign": "4.1.1",
-        "resolve": "1.3.3",
+        "ignore": "^3.0.11",
+        "minimatch": "^3.0.2",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.7",
         "semver": "5.3.0"
       }
     },
@@ -645,11 +659,11 @@
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
       "requires": {
-        "array.prototype.find": "2.0.4",
-        "doctrine": "1.5.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1",
-        "object.assign": "4.0.4"
+        "array.prototype.find": "^2.0.1",
+        "doctrine": "^1.2.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^1.3.4",
+        "object.assign": "^4.0.4"
       },
       "dependencies": {
         "doctrine": {
@@ -658,8 +672,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         }
       }
@@ -671,46 +685,37 @@
       "dev": true
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.0.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.1.1",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -731,8 +736,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "exit-hook": {
@@ -746,7 +751,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.1"
       }
     },
     "extend-shallow": {
@@ -754,7 +759,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "fast-levenshtein": {
@@ -769,8 +774,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -779,8 +784,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "find-config": {
@@ -788,13 +793,13 @@
       "resolved": "https://registry.npmjs.org/find-config/-/find-config-1.0.0.tgz",
       "integrity": "sha1-6vorm8B/qckOmgw++c7PHMgA9TA=",
       "requires": {
-        "user-home": "2.0.0"
+        "user-home": "^2.0.0"
       }
     },
     "find-root": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
-      "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "find-up": {
@@ -803,20 +808,20 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "foreach": {
@@ -831,13 +836,8 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
-    },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
     },
     "fs-exists-sync": {
       "version": "0.1.0",
@@ -850,9 +850,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "generate-function": {
@@ -867,13 +867,14 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-stdin": {
       "version": "5.0.1",
@@ -886,12 +887,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global-modules": {
@@ -899,8 +900,8 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       }
     },
     "global-prefix": {
@@ -908,10 +909,10 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "0.2.0",
-        "which": "1.2.14"
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
       }
     },
     "globals": {
@@ -926,12 +927,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -952,12 +953,12 @@
       "dev": true
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -965,7 +966,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -979,21 +980,27 @@
       "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
       "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.1"
       }
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -1007,8 +1014,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1027,25 +1034,25 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "is-arrayish": {
@@ -1060,9 +1067,9 @@
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-date-object": {
@@ -1087,7 +1094,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -1095,19 +1102,26 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-path-cwd": {
@@ -1117,21 +1131,21 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-property": {
@@ -1146,17 +1160,14 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -1186,20 +1197,26 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
-      "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "3.1.3"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -1207,7 +1224,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json3": {
@@ -1221,7 +1238,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.0.tgz",
       "integrity": "sha1-kufHRE5f/V+jLmqa6LhQNN+DR9A=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -1253,7 +1270,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1261,7 +1278,7 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "levn": {
@@ -1270,20 +1287,28 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -1292,8 +1317,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -1305,9 +1330,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "lodash._baseassign": {
@@ -1316,8 +1341,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -1356,9 +1381,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.get": {
@@ -1385,9 +1410,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "log-symbols": {
@@ -1395,7 +1420,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "lolex": {
@@ -1409,15 +1434,15 @@
       "resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
       "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
       "requires": {
-        "arr-union": "3.1.0",
-        "async-array-reduce": "0.2.1",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "glob": "7.1.2",
-        "has-glob": "0.1.1",
-        "is-valid-glob": "0.3.0",
-        "lazy-cache": "2.0.2",
-        "resolve-dir": "0.1.1"
+        "arr-union": "^3.1.0",
+        "async-array-reduce": "^0.2.0",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "glob": "^7.0.5",
+        "has-glob": "^0.1.1",
+        "is-valid-glob": "^0.3.0",
+        "lazy-cache": "^2.0.1",
+        "resolve-dir": "^0.1.0"
       }
     },
     "minimatch": {
@@ -1425,7 +1450,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1468,12 +1493,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -1496,17 +1521,23 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
     "nise": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
       "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.27",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "formatio": "^1.2.0",
+        "just-extend": "^1.1.26",
+        "lolex": "^1.6.0",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "lolex": {
@@ -1514,3937 +1545,6 @@
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
           "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
           "dev": true
-        }
-      }
-    },
-    "npm": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-5.7.1.tgz",
-      "integrity": "sha512-r1grvv6mcEt+nlMzMWPc5n/z5q8NNuBWj0TGFp1PBSFCl6ubnAoUGBsucYsnZYT7MOJn0ha1ptEjmdBoAdJ+SA==",
-      "requires": {
-        "JSONStream": "1.3.2",
-        "abbrev": "1.1.1",
-        "ansi-regex": "3.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.0",
-        "bluebird": "3.5.1",
-        "cacache": "10.0.4",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "cli-table2": "0.2.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.5.0",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.1",
-        "is-cidr": "1.0.0",
-        "lazy-property": "1.0.0",
-        "libcipm": "1.3.3",
-        "libnpx": "9.7.1",
-        "lockfile": "1.0.3",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.1",
-        "meant": "1.0.1",
-        "mississippi": "2.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.0",
-        "npm-package-arg": "6.0.0",
-        "npm-packlist": "1.1.10",
-        "npm-profile": "3.0.1",
-        "npm-registry-client": "8.5.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.5",
-        "pacote": "7.3.3",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.11.0",
-        "query-string": "5.1.0",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.12",
-        "read-package-tree": "5.1.6",
-        "readable-stream": "2.3.4",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.83.0",
-        "retry": "0.10.1",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
-        "semver": "5.5.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "5.2.4",
-        "strip-ansi": "4.0.0",
-        "tar": "4.3.3",
-        "text-table": "0.2.0",
-        "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.3.0",
-        "uuid": "3.2.1",
-        "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.5.2",
-        "wrappy": "1.0.2",
-        "write-file-atomic": "2.1.0"
-      },
-      "dependencies": {
-        "JSONStream": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
-          }
-        },
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "ansicolors": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "ansistyles": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "bin-links": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "fs-write-stream-atomic": "1.0.10",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "slide": "1.1.6"
-          }
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "bundled": true
-        },
-        "cacache": {
-          "version": "10.0.4",
-          "bundled": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.1",
-            "mississippi": "2.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "5.2.4",
-            "unique-filename": "1.1.0",
-            "y18n": "4.0.0"
-          },
-          "dependencies": {
-            "y18n": {
-              "version": "4.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "call-limit": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "cli-table2": {
-          "version": "0.2.0",
-          "bundled": true,
-          "requires": {
-            "colors": "1.1.2",
-            "lodash": "3.10.1",
-            "string-width": "1.0.2"
-          },
-          "dependencies": {
-            "colors": {
-              "version": "1.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              },
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "cmd-shim": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
-          }
-        },
-        "columnify": {
-          "version": "1.5.4",
-          "bundled": true,
-          "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true
-                }
-              }
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "defaults": "1.0.3"
-              },
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "clone": "1.0.2"
-                  },
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "config-chain": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
-          },
-          "dependencies": {
-            "proto-list": {
-              "version": "1.2.4",
-              "bundled": true
-            }
-          }
-        },
-        "debuglog": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "detect-indent": {
-          "version": "5.0.0",
-          "bundled": true
-        },
-        "dezalgo": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "asap": "2.0.5",
-            "wrappy": "1.0.2"
-          },
-          "dependencies": {
-            "asap": {
-              "version": "2.0.5",
-              "bundled": true
-            }
-          }
-        },
-        "editor": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "find-npm-prefix": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "fs-vacuum": {
-          "version": "1.2.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
-          }
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.10",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.4"
-          }
-        },
-        "gentle-fs": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          },
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "bundled": true
-        },
-        "iferr": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "init-package-json": {
-          "version": "1.10.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "5.1.2",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.12",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "3.0.0"
-          },
-          "dependencies": {
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.5",
-                "semver": "5.5.0",
-                "validate-npm-package-name": "3.0.0"
-              }
-            },
-            "promzard": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1.0.7"
-              }
-            }
-          }
-        },
-        "is-cidr": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "cidr-regex": "1.0.6"
-          },
-          "dependencies": {
-            "cidr-regex": {
-              "version": "1.0.6",
-              "bundled": true
-            }
-          }
-        },
-        "lazy-property": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "libcipm": {
-          "version": "1.3.3",
-          "bundled": true,
-          "requires": {
-            "bin-links": "1.1.0",
-            "bluebird": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.0",
-            "npm-lifecycle": "2.0.0",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.0.0",
-            "pacote": "7.3.3",
-            "protoduck": "5.0.0",
-            "read-package-json": "2.0.12",
-            "rimraf": "2.6.2",
-            "worker-farm": "1.5.2"
-          },
-          "dependencies": {
-            "find-npm-prefix": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "lock-verify": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.5.0"
-              },
-              "dependencies": {
-                "npm-package-arg": {
-                  "version": "5.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "hosted-git-info": "2.5.0",
-                    "osenv": "0.1.5",
-                    "semver": "5.5.0",
-                    "validate-npm-package-name": "3.0.0"
-                  }
-                }
-              }
-            },
-            "npm-logical-tree": {
-              "version": "1.2.1",
-              "bundled": true
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "worker-farm": {
-              "version": "1.5.2",
-              "bundled": true,
-              "requires": {
-                "errno": "0.1.7",
-                "xtend": "4.0.1"
-              },
-              "dependencies": {
-                "errno": {
-                  "version": "0.1.7",
-                  "bundled": true,
-                  "requires": {
-                    "prr": "1.0.1"
-                  },
-                  "dependencies": {
-                    "prr": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "libnpx": {
-          "version": "9.7.1",
-          "bundled": true,
-          "requires": {
-            "dotenv": "4.0.0",
-            "npm-package-arg": "5.1.2",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.3.0",
-            "which": "1.3.0",
-            "y18n": "3.2.1",
-            "yargs": "8.0.2"
-          },
-          "dependencies": {
-            "dotenv": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.5",
-                "semver": "5.5.0",
-                "validate-npm-package-name": "3.0.0"
-              }
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "8.0.2",
-              "bundled": true,
-              "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "read-pkg-up": "2.0.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cliui": {
-                  "version": "3.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.1.0"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
-                      }
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "bundled": true
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "os-locale": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.1.1",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "2.0.1"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "lcid": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "invert-kv": "1.0.0"
-                      },
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "mem": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "mimic-fn": "1.1.0"
-                      },
-                      "dependencies": {
-                        "mimic-fn": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "find-up": "2.1.0",
-                    "read-pkg": "2.0.0"
-                  },
-                  "dependencies": {
-                    "find-up": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "locate-path": "2.0.0"
-                      },
-                      "dependencies": {
-                        "locate-path": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "p-locate": "2.0.0",
-                            "path-exists": "3.0.0"
-                          },
-                          "dependencies": {
-                            "p-locate": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "p-limit": "1.1.0"
-                              },
-                              "dependencies": {
-                                "p-limit": {
-                                  "version": "1.1.0",
-                                  "bundled": true
-                                }
-                              }
-                            },
-                            "path-exists": {
-                              "version": "3.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
-                      },
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "graceful-fs": "4.1.11",
-                            "parse-json": "2.2.0",
-                            "pify": "2.3.0",
-                            "strip-bom": "3.0.0"
-                          },
-                          "dependencies": {
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "error-ex": "1.3.1"
-                              },
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.1",
-                                  "bundled": true,
-                                  "requires": {
-                                    "is-arrayish": "0.2.1"
-                                  },
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "bundled": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true
-                            },
-                            "strip-bom": {
-                              "version": "3.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "pify": "2.3.0"
-                          },
-                          "dependencies": {
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "bundled": true
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "bundled": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "yargs-parser": {
-                  "version": "7.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "camelcase": "4.1.0"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "lockfile": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "lodash._baseuniq": {
-          "version": "4.6.0",
-          "bundled": true,
-          "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
-          },
-          "dependencies": {
-            "lodash._createset": {
-              "version": "4.0.3",
-              "bundled": true
-            },
-            "lodash._root": {
-              "version": "3.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "lodash._createcache": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "3.9.1"
-          }
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "bundled": true
-        },
-        "lodash.union": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "lodash.uniq": {
-          "version": "4.5.0",
-          "bundled": true
-        },
-        "lodash.without": {
-          "version": "4.4.0",
-          "bundled": true
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "bundled": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          },
-          "dependencies": {
-            "pseudomap": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "2.1.2",
-              "bundled": true
-            }
-          }
-        },
-        "meant": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "mississippi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "duplexify": "3.5.3",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "2.0.1",
-            "pumpify": "1.4.0",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.4",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "duplexify": {
-              "version": "3.5.3",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.4",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "end-of-stream": {
-              "version": "1.4.1",
-              "bundled": true,
-              "requires": {
-                "once": "1.4.0"
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.4"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.4"
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.4"
-              },
-              "dependencies": {
-                "cyclist": {
-                  "version": "0.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "pump": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
-              }
-            },
-            "pumpify": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "duplexify": "3.5.3",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
-              }
-            },
-            "stream-each": {
-              "version": "1.2.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.4",
-                "xtend": "4.0.1"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
-          }
-        },
-        "move-concurrently": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
-          },
-          "dependencies": {
-            "copy-concurrently": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0"
-              }
-            }
-          }
-        },
-        "node-gyp": {
-          "version": "3.6.2",
-          "bundled": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.5",
-            "request": "2.83.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.0"
-          },
-          "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1.1.1"
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.1"
-          },
-          "dependencies": {
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "1.1.1"
-              },
-              "dependencies": {
-                "builtin-modules": {
-                  "version": "1.1.1",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "npm-cache-filename": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "npm-install-checks": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "semver": "5.5.0"
-          }
-        },
-        "npm-lifecycle": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.6.2",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
-            "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.0"
-          },
-          "dependencies": {
-            "byline": {
-              "version": "5.0.0",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "4.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "npm-package-arg": {
-          "version": "6.0.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
-          }
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
-          },
-          "dependencies": {
-            "ignore-walk": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "minimatch": "3.0.4"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "1.1.8"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "npm-profile": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "2.6.0"
-          },
-          "dependencies": {
-            "make-fetch-happen": {
-              "version": "2.6.0",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.2.4"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "2.6.9"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "2.6.9",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "mississippi": {
-                  "version": "1.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
-                  },
-                  "dependencies": {
-                    "concat-stream": {
-                      "version": "1.6.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
-                        "typedarray": "0.0.6"
-                      },
-                      "dependencies": {
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "duplexify": {
-                      "version": "3.5.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
-                        "stream-shift": "1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "once": "1.4.0"
-                      }
-                    },
-                    "flush-write-stream": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
-                      }
-                    },
-                    "from2": {
-                      "version": "2.3.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
-                      }
-                    },
-                    "parallel-transform": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
-                      },
-                      "dependencies": {
-                        "cyclist": {
-                          "version": "0.2.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "pump": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
-                      }
-                    },
-                    "pumpify": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "duplexify": "3.5.3",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
-                      },
-                      "dependencies": {
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
-                          }
-                        }
-                      }
-                    },
-                    "stream-each": {
-                      "version": "1.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "readable-stream": "2.3.4",
-                        "xtend": "4.0.1"
-                      },
-                      "dependencies": {
-                        "xtend": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.19"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.19",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "json-parse-better-errors": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "promise-retry": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
-                  },
-                  "dependencies": {
-                    "err-code": {
-                      "version": "1.1.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "npm-registry-client": {
-          "version": "8.5.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.83.0",
-            "retry": "0.10.1",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "ssri": "4.1.6"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.4",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "npm-package-arg": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "2.5.0",
-                "osenv": "0.1.5",
-                "semver": "5.5.0",
-                "validate-npm-package-name": "3.0.0"
-              }
-            },
-            "ssri": {
-              "version": "4.1.6",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "npm-user-validate": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "bundled": true,
-              "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.4"
-              },
-              "dependencies": {
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
-              },
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "bundled": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "number-is-nan": "1.0.1"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "wide-align": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  }
-                }
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "opener": {
-          "version": "1.4.3",
-          "bundled": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          },
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "os-tmpdir": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "pacote": {
-          "version": "7.3.3",
-          "bundled": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "10.0.4",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.1",
-            "make-fetch-happen": "2.6.0",
-            "minimatch": "3.0.4",
-            "mississippi": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.0.0",
-            "npm-packlist": "1.1.10",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.0",
-            "safe-buffer": "5.1.1",
-            "semver": "5.5.0",
-            "ssri": "5.2.4",
-            "tar": "4.3.3",
-            "unique-filename": "1.1.0",
-            "which": "1.3.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "make-fetch-happen": {
-              "version": "2.6.0",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.1",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.2.4"
-              },
-              "dependencies": {
-                "agentkeepalive": {
-                  "version": "3.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "humanize-ms": "1.2.1"
-                  },
-                  "dependencies": {
-                    "humanize-ms": {
-                      "version": "1.2.1",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.1.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "http-cache-semantics": {
-                  "version": "3.8.1",
-                  "bundled": true
-                },
-                "http-proxy-agent": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "2.6.9"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "2.6.9",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "https-proxy-agent": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "mississippi": {
-                  "version": "1.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
-                  },
-                  "dependencies": {
-                    "concat-stream": {
-                      "version": "1.6.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
-                        "typedarray": "0.0.6"
-                      },
-                      "dependencies": {
-                        "typedarray": {
-                          "version": "0.0.6",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "duplexify": {
-                      "version": "3.5.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4",
-                        "stream-shift": "1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "end-of-stream": {
-                      "version": "1.4.1",
-                      "bundled": true,
-                      "requires": {
-                        "once": "1.4.0"
-                      }
-                    },
-                    "flush-write-stream": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
-                      }
-                    },
-                    "from2": {
-                      "version": "2.3.0",
-                      "bundled": true,
-                      "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
-                      }
-                    },
-                    "parallel-transform": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.4"
-                      },
-                      "dependencies": {
-                        "cyclist": {
-                          "version": "0.2.2",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "pump": {
-                      "version": "1.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
-                      }
-                    },
-                    "pumpify": {
-                      "version": "1.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "duplexify": "3.5.3",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
-                      },
-                      "dependencies": {
-                        "pump": {
-                          "version": "2.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
-                          }
-                        }
-                      }
-                    },
-                    "stream-each": {
-                      "version": "1.2.2",
-                      "bundled": true,
-                      "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
-                      },
-                      "dependencies": {
-                        "stream-shift": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "through2": {
-                      "version": "2.0.3",
-                      "bundled": true,
-                      "requires": {
-                        "readable-stream": "2.3.4",
-                        "xtend": "4.0.1"
-                      },
-                      "dependencies": {
-                        "xtend": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "node-fetch-npm": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
-                  },
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "bundled": true,
-                      "requires": {
-                        "iconv-lite": "0.4.19"
-                      },
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.19",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "json-parse-better-errors": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "socks-proxy-agent": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
-                  },
-                  "dependencies": {
-                    "agent-base": {
-                      "version": "4.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "es6-promisify": "5.0.0"
-                      },
-                      "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "es6-promise": "4.2.4"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.2.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "socks": {
-                      "version": "1.1.10",
-                      "bundled": true,
-                      "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
-                      },
-                      "dependencies": {
-                        "ip": {
-                          "version": "1.1.5",
-                          "bundled": true
-                        },
-                        "smart-buffer": {
-                          "version": "1.1.15",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "1.1.11"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "1.0.0",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "mississippi": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "concat-stream": "1.6.0",
-                "duplexify": "3.5.3",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.2",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.4.0",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
-              },
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4",
-                    "typedarray": "0.0.6"
-                  },
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "bundled": true
-                    }
-                  }
-                },
-                "duplexify": {
-                  "version": "3.5.3",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.1",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4",
-                    "stream-shift": "1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "end-of-stream": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "once": "1.4.0"
-                  }
-                },
-                "flush-write-stream": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4"
-                  }
-                },
-                "from2": {
-                  "version": "2.3.0",
-                  "bundled": true,
-                  "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4"
-                  }
-                },
-                "parallel-transform": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "cyclist": "0.2.2",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.4"
-                  },
-                  "dependencies": {
-                    "cyclist": {
-                      "version": "0.2.2",
-                      "bundled": true
-                    }
-                  }
-                },
-                "pump": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
-                  }
-                },
-                "pumpify": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "duplexify": "3.5.3",
-                    "inherits": "2.0.3",
-                    "pump": "2.0.1"
-                  }
-                },
-                "stream-each": {
-                  "version": "1.2.2",
-                  "bundled": true,
-                  "requires": {
-                    "end-of-stream": "1.4.1",
-                    "stream-shift": "1.0.0"
-                  },
-                  "dependencies": {
-                    "stream-shift": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "through2": {
-                  "version": "2.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "readable-stream": "2.3.4",
-                    "xtend": "4.0.1"
-                  },
-                  "dependencies": {
-                    "xtend": {
-                      "version": "4.0.1",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "npm-pick-manifest": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "npm-package-arg": "6.0.0",
-                "semver": "5.5.0"
-              }
-            },
-            "promise-retry": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
-              },
-              "dependencies": {
-                "err-code": {
-                  "version": "1.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "protoduck": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "genfun": "4.0.1"
-              },
-              "dependencies": {
-                "genfun": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "semver": {
-              "version": "5.5.0",
-              "bundled": true
-            }
-          }
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "promise-inflight": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "qrcode-terminal": {
-          "version": "0.11.0",
-          "bundled": true
-        },
-        "query-string": {
-          "version": "5.1.0",
-          "bundled": true,
-          "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
-          },
-          "dependencies": {
-            "decode-uri-component": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "bundled": true
-            },
-            "strict-uri-encode": {
-              "version": "1.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "qw": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "read": {
-          "version": "1.0.7",
-          "bundled": true,
-          "requires": {
-            "mute-stream": "0.0.7"
-          },
-          "dependencies": {
-            "mute-stream": {
-              "version": "0.0.7",
-              "bundled": true
-            }
-          }
-        },
-        "read-cmd-shim": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "read-installed": {
-          "version": "4.0.3",
-          "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.12",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
-          },
-          "dependencies": {
-            "util-extend": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "read-package-json": {
-          "version": "2.0.12",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
-          },
-          "dependencies": {
-            "json-parse-better-errors": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "read-package-tree": {
-          "version": "5.1.6",
-          "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.12",
-            "readdir-scoped-modules": "1.0.2"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.4",
-          "bundled": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "process-nextick-args": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "readdir-scoped-modules": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          },
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.7.0",
-              "bundled": true
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "bundled": true
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "delayed-stream": "1.0.0"
-              },
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "bundled": true
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "bundled": true
-            },
-            "form-data": {
-              "version": "2.3.1",
-              "bundled": true,
-              "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
-              },
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "bundled": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "ajv": "5.2.3",
-                "har-schema": "2.0.0"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "5.2.3",
-                  "bundled": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.0.0",
-                    "json-schema-traverse": "0.3.1",
-                    "json-stable-stringify": "1.0.1"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "bundled": true
-                    },
-                    "fast-deep-equal": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "json-schema-traverse": {
-                      "version": "0.3.1",
-                      "bundled": true
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "requires": {
-                        "jsonify": "0.0.0"
-                      },
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "hawk": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.0.2"
-              },
-              "dependencies": {
-                "boom": {
-                  "version": "4.3.1",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.0"
-                  }
-                },
-                "cryptiles": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "boom": "5.2.0"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "5.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "hoek": "4.2.0"
-                      }
-                    }
-                  }
-                },
-                "hoek": {
-                  "version": "4.2.0",
-                  "bundled": true
-                },
-                "sntp": {
-                  "version": "2.0.2",
-                  "bundled": true,
-                  "requires": {
-                    "hoek": "4.2.0"
-                  }
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
-              },
-              "dependencies": {
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "jsprim": {
-                  "version": "1.4.1",
-                  "bundled": true,
-                  "requires": {
-                    "assert-plus": "1.0.0",
-                    "extsprintf": "1.3.0",
-                    "json-schema": "0.2.3",
-                    "verror": "1.10.0"
-                  },
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.3.0",
-                      "bundled": true
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "verror": {
-                      "version": "1.10.0",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
-                      },
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.1",
-                  "bundled": true,
-                  "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
-                  },
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "bundled": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "tweetnacl": "0.14.5"
-                      }
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "jsbn": "0.1.1"
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "bundled": true,
-                      "requires": {
-                        "assert-plus": "1.0.0"
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "bundled": true
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "mime-types": {
-              "version": "2.1.17",
-              "bundled": true,
-              "requires": {
-                "mime-db": "1.30.0"
-              },
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.30.0",
-                  "bundled": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "bundled": true
-            },
-            "performance-now": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "qs": {
-              "version": "6.5.1",
-              "bundled": true
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "bundled": true
-            },
-            "tough-cookie": {
-              "version": "2.3.3",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "retry": {
-          "version": "0.10.1",
-          "bundled": true
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true
-        },
-        "sha": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.4"
-          }
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true
-        },
-        "sorted-object": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "sorted-union-stream": {
-          "version": "2.1.3",
-          "bundled": true,
-          "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
-          },
-          "dependencies": {
-            "from2": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "stream-iterate": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.3.4",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "ssri": {
-          "version": "5.2.4",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "tar": {
-          "version": "4.3.3",
-          "bundled": true,
-          "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.1",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "yallist": "3.0.2"
-          },
-          "dependencies": {
-            "fs-minipass": {
-              "version": "1.2.5",
-              "bundled": true,
-              "requires": {
-                "minipass": "2.2.1"
-              }
-            },
-            "minipass": {
-              "version": "2.2.1",
-              "bundled": true,
-              "requires": {
-                "yallist": "3.0.2"
-              }
-            },
-            "minizlib": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "minipass": "2.2.1"
-              }
-            },
-            "yallist": {
-              "version": "3.0.2",
-              "bundled": true
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true
-        },
-        "umask": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "unique-filename": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "unique-slug": "2.0.0"
-          },
-          "dependencies": {
-            "unique-slug": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "0.1.4"
-              }
-            }
-          }
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "update-notifier": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "boxen": "1.2.1",
-            "chalk": "2.1.0",
-            "configstore": "3.1.1",
-            "import-lazy": "2.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
-          },
-          "dependencies": {
-            "boxen": {
-              "version": "1.2.1",
-              "bundled": true,
-              "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.1.0",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "1.0.0"
-              },
-              "dependencies": {
-                "ansi-align": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "2.1.1"
-                  }
-                },
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true
-                },
-                "cli-boxes": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "term-size": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "0.7.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.1.1",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "requires": {
-                                "shebang-regex": "1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "2.0.1"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "widest-line": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "3.2.0",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "4.4.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "3.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "color-convert": "1.9.0"
-                  },
-                  "dependencies": {
-                    "color-convert": {
-                      "version": "1.9.0",
-                      "bundled": true,
-                      "requires": {
-                        "color-name": "1.1.3"
-                      },
-                      "dependencies": {
-                        "color-name": {
-                          "version": "1.1.3",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "bundled": true
-                },
-                "supports-color": {
-                  "version": "4.4.0",
-                  "bundled": true,
-                  "requires": {
-                    "has-flag": "2.0.0"
-                  },
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "configstore": {
-              "version": "3.1.1",
-              "bundled": true,
-              "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.0.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.1.0",
-                "xdg-basedir": "3.0.0"
-              },
-              "dependencies": {
-                "dot-prop": {
-                  "version": "4.2.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-obj": "1.0.1"
-                  },
-                  "dependencies": {
-                    "is-obj": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "make-dir": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "pify": "2.3.0"
-                  },
-                  "dependencies": {
-                    "pify": {
-                      "version": "2.3.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "unique-string": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "1.0.0"
-                  },
-                  "dependencies": {
-                    "crypto-random-string": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "bundled": true
-            },
-            "is-installed-globally": {
-              "version": "0.1.0",
-              "bundled": true,
-              "requires": {
-                "global-dirs": "0.1.0",
-                "is-path-inside": "1.0.0"
-              },
-              "dependencies": {
-                "global-dirs": {
-                  "version": "0.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "ini": "1.3.5"
-                  }
-                },
-                "is-path-inside": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "path-is-inside": "1.0.2"
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "latest-version": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "package-json": "4.0.1"
-              },
-              "dependencies": {
-                "package-json": {
-                  "version": "4.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.1",
-                    "registry-url": "3.1.0",
-                    "semver": "5.5.0"
-                  },
-                  "dependencies": {
-                    "got": {
-                      "version": "6.7.1",
-                      "bundled": true,
-                      "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
-                      },
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "1.0.0"
-                          },
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexer3": {
-                          "version": "0.1.4",
-                          "bundled": true
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "is-retry-allowed": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "timed-out": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        },
-                        "unzip-response": {
-                          "version": "2.0.1",
-                          "bundled": true
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "prepend-http": "1.0.4"
-                          },
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-auth-token": {
-                      "version": "3.3.1",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "1.2.1",
-                        "safe-buffer": "5.1.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.2",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "1.2.1"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.2.1",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.2",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.2",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "5.5.0"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "bundled": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          },
-          "dependencies": {
-            "spdx-correct": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "spdx-license-ids": "1.2.2"
-              },
-              "dependencies": {
-                "spdx-license-ids": {
-                  "version": "1.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "1.0.4",
-              "bundled": true
-            }
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "builtins": "1.0.3"
-          },
-          "dependencies": {
-            "builtins": {
-              "version": "1.0.3",
-              "bundled": true
-            }
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "isexe": "2.0.0"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "worker-farm": {
-          "version": "1.5.2",
-          "bundled": true,
-          "requires": {
-            "errno": "0.1.7",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "errno": {
-              "version": "0.1.7",
-              "bundled": true,
-              "requires": {
-                "prr": "1.0.1"
-              },
-              "dependencies": {
-                "prr": {
-                  "version": "1.0.1",
-                  "bundled": true
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write-file-atomic": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
         }
       }
     },
@@ -5460,33 +1560,33 @@
       "integrity": "sha512-31rRd6ME9NM17w0oPKqi51a6fzJAqYarnzQXK+iL8XaX+3H6VH0BQut7qHIgrv2mBASRic4oNi2KRgcbFODrsQ==",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.0",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.7.2",
-        "istanbul-lib-report": "1.1.1",
-        "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.1",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.3",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.1",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.3.6",
-        "test-exclude": "4.1.1",
-        "yargs": "8.0.1",
-        "yargs-parser": "5.0.0"
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.3.0",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.0.7",
+        "istanbul-lib-instrument": "^1.7.2",
+        "istanbul-lib-report": "^1.1.1",
+        "istanbul-lib-source-maps": "^1.2.1",
+        "istanbul-reports": "^1.1.1",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.0.2",
+        "micromatch": "^2.3.11",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.4",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.3.6",
+        "test-exclude": "^4.1.1",
+        "yargs": "^8.0.1",
+        "yargs-parser": "^5.0.0"
       },
       "dependencies": {
         "align-text": {
@@ -5494,9 +1594,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -5519,7 +1619,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
@@ -5532,7 +1632,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.0.3"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -5560,9 +1660,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.1"
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
           }
         },
         "babel-generator": {
@@ -5570,14 +1670,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.23.0",
-            "babel-types": "6.24.1",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.6",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-messages": {
@@ -5585,7 +1685,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.23.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -5593,8 +1693,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.4.1",
-            "regenerator-runtime": "0.10.5"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
           }
         },
         "babel-template": {
@@ -5602,11 +1702,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.23.0",
-            "babel-traverse": "6.24.1",
-            "babel-types": "6.24.1",
-            "babylon": "6.17.2",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1",
+            "babylon": "^6.11.0",
+            "lodash": "^4.2.0"
           }
         },
         "babel-traverse": {
@@ -5614,15 +1714,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.22.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.23.0",
-            "babel-types": "6.24.1",
-            "babylon": "6.17.2",
-            "debug": "2.6.8",
-            "globals": "9.17.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.22.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1",
+            "babylon": "^6.15.0",
+            "debug": "^2.2.0",
+            "globals": "^9.0.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
           }
         },
         "babel-types": {
@@ -5630,10 +1730,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.23.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.22.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^1.0.1"
           }
         },
         "babylon": {
@@ -5651,7 +1751,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -5660,9 +1760,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "builtin-modules": {
@@ -5675,9 +1775,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           }
         },
         "center-align": {
@@ -5686,8 +1786,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -5695,11 +1795,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cliui": {
@@ -5708,8 +1808,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -5751,8 +1851,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.0.2",
-            "which": "1.2.14"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -5778,7 +1878,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           }
         },
         "detect-indent": {
@@ -5786,7 +1886,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "error-ex": {
@@ -5794,7 +1894,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -5812,13 +1912,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "get-stream": "2.3.1",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^4.0.0",
+            "get-stream": "^2.2.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "expand-brackets": {
@@ -5826,7 +1926,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -5834,7 +1934,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -5842,7 +1942,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
@@ -5855,11 +1955,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.6",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "find-cache-dir": {
@@ -5867,9 +1967,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -5877,7 +1977,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "for-in": {
@@ -5890,7 +1990,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "foreground-child": {
@@ -5898,8 +1998,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -5917,8 +2017,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "glob": {
@@ -5926,12 +2026,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -5939,8 +2039,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -5948,7 +2048,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -5966,10 +2066,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.27"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -5977,7 +2077,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -5987,7 +2087,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -6010,8 +2110,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -6024,7 +2124,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -6047,7 +2147,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-dotfile": {
@@ -6060,7 +2160,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -6078,7 +2178,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -6086,7 +2186,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-glob": {
@@ -6094,7 +2194,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -6102,7 +2202,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-posix-bracket": {
@@ -6153,7 +2253,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "0.4.0"
+            "append-transform": "^0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -6161,13 +2261,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.24.1",
-            "babel-template": "6.24.1",
-            "babel-traverse": "6.24.1",
-            "babel-types": "6.24.1",
-            "babylon": "6.17.2",
-            "istanbul-lib-coverage": "1.1.1",
-            "semver": "5.3.0"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.13.0",
+            "istanbul-lib-coverage": "^1.1.1",
+            "semver": "^5.3.0"
           }
         },
         "istanbul-lib-report": {
@@ -6175,10 +2275,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "supports-color": {
@@ -6186,7 +2286,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -6196,11 +2296,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.6.8",
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1",
-            "source-map": "0.5.6"
+            "debug": "^2.6.3",
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           }
         },
         "istanbul-reports": {
@@ -6208,7 +2308,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.10"
+            "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
@@ -6226,7 +2326,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -6240,7 +2340,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -6248,11 +2348,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "locate-path": {
@@ -6260,8 +2360,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -6286,7 +2386,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.1"
+            "js-tokens": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -6294,8 +2394,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.1",
+            "yallist": "^2.0.0"
           }
         },
         "md5-hex": {
@@ -6303,7 +2403,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
@@ -6316,7 +2416,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "merge-source-map": {
@@ -6324,7 +2424,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.5.6"
+            "source-map": "^0.5.3"
           }
         },
         "micromatch": {
@@ -6332,19 +2432,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.3"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "mimic-fn": {
@@ -6357,7 +2457,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -6383,10 +2483,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.4.2",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.3.0",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -6394,7 +2494,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.0.1"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "npm-run-path": {
@@ -6402,7 +2502,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -6420,8 +2520,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "once": {
@@ -6429,7 +2529,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimist": {
@@ -6437,8 +2537,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-homedir": {
@@ -6451,9 +2551,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.5.1",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.5.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "p-finally": {
@@ -6471,7 +2571,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.1.0"
+            "p-limit": "^1.1.0"
           }
         },
         "parse-glob": {
@@ -6479,10 +2579,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -6490,7 +2590,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -6498,7 +2598,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -6521,9 +2621,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -6541,7 +2641,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -6549,7 +2649,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -6557,8 +2657,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -6578,8 +2678,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "kind-of": "3.2.2"
+            "is-number": "^2.0.2",
+            "kind-of": "^3.0.2"
           }
         },
         "read-pkg": {
@@ -6587,9 +2687,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.3.8",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -6597,8 +2697,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -6606,8 +2706,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -6622,8 +2722,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3",
-            "is-primitive": "2.0.0"
+            "is-equal-shallow": "^0.1.3",
+            "is-primitive": "^2.0.0"
           }
         },
         "remove-trailing-separator": {
@@ -6646,7 +2746,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
@@ -6670,7 +2770,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -6678,7 +2778,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "semver": {
@@ -6711,12 +2811,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.1",
-            "signal-exit": "3.0.2",
-            "which": "1.2.14"
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.3.3",
+            "signal-exit": "^3.0.2",
+            "which": "^1.2.4"
           }
         },
         "spdx-correct": {
@@ -6724,7 +2824,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -6742,8 +2842,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^3.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -6758,7 +2858,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -6766,7 +2866,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
@@ -6784,11 +2884,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           }
         },
         "to-fast-properties": {
@@ -6807,9 +2907,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "camelcase": {
@@ -6824,9 +2924,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -6843,8 +2943,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "which": {
@@ -6852,7 +2952,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -6876,8 +2976,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
@@ -6885,9 +2985,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -6902,9 +3002,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "y18n": {
@@ -6922,19 +3022,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.0.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.0.0",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           },
           "dependencies": {
             "camelcase": {
@@ -6947,9 +3047,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
               },
               "dependencies": {
                 "string-width": {
@@ -6957,9 +3057,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   }
                 }
               }
@@ -6969,10 +3069,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
               }
             },
             "path-type": {
@@ -6980,7 +3080,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pify": "2.3.0"
+                "pify": "^2.0.0"
               }
             },
             "read-pkg": {
@@ -6988,9 +3088,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "load-json-file": "2.0.0",
-                "normalize-package-data": "2.3.8",
-                "path-type": "2.0.0"
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
               }
             },
             "read-pkg-up": {
@@ -6998,8 +3098,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "2.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
               }
             },
             "strip-bom": {
@@ -7012,7 +3112,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
               }
             }
           }
@@ -7022,7 +3122,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           },
           "dependencies": {
             "camelcase": {
@@ -7041,20 +3141,21 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "object.assign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.0",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "once": {
@@ -7062,12 +3163,12 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -7077,12 +3178,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -7091,10 +3192,13 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -7102,16 +3206,23 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse-passwd": {
@@ -7119,22 +3230,13 @@
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "0.11.10",
-        "util": "0.10.3"
-      }
-    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -7174,7 +3276,8 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -7194,17 +3297,17 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-conf": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
-      "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "2.0.0"
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -7213,7 +3316,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -7224,9 +3327,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.0.0",
-        "xtend": "4.0.1"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -7235,7 +3338,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pkg-up": {
@@ -7244,7 +3347,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pluralize": {
@@ -7259,15 +3362,10 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
-    },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
@@ -7277,18 +3375,18 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.0.1",
-        "string_decoder": "1.0.2",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -7297,8 +3395,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -7308,7 +3406,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "^1.1.6"
       }
     },
     "require-uncached": {
@@ -7317,17 +3415,17 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -7335,8 +3433,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       }
     },
     "resolve-from": {
@@ -7351,8 +3449,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
@@ -7360,7 +3458,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -7369,13 +3467,13 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-parallel": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "rx-lite": {
@@ -7385,9 +3483,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "samsam": {
@@ -7407,7 +3505,7 @@
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "shelljs": {
@@ -7416,9 +3514,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.3",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "simple-git": {
@@ -7426,7 +3524,7 @@
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.73.0.tgz",
       "integrity": "sha1-h2g6cpsb7gFqMYL5Wiq3Ixe7AjA=",
       "requires": {
-        "debug": "2.6.8"
+        "debug": "^2.6.7"
       },
       "dependencies": {
         "debug": {
@@ -7450,13 +3548,13 @@
       "integrity": "sha512-5uLBZPdCWl59Lpbf45ygKj7Z0LVol+ftBe7RDIXOQV/sF58pcFmbK8raA7bt6eljNuGnvBP+/ZxlicVn0emDjA==",
       "dev": true,
       "requires": {
-        "diff": "3.2.0",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.0",
-        "nise": "1.2.0",
-        "supports-color": "4.5.0",
-        "type-detect": "4.0.3"
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^4.4.0",
+        "type-detect": "^4.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -7471,7 +3569,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -7489,20 +3587,20 @@
       "dev": true
     },
     "standard": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.2.tgz",
-      "integrity": "sha1-l0wcU8yGWwdaS1dueEQeFpXar3s=",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
+      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
-        "eslint": "3.19.0",
+        "eslint": "~3.19.0",
         "eslint-config-standard": "10.2.1",
-        "eslint-config-standard-jsx": "4.0.1",
-        "eslint-plugin-import": "2.2.0",
-        "eslint-plugin-node": "4.2.2",
-        "eslint-plugin-promise": "3.5.0",
-        "eslint-plugin-react": "6.10.3",
-        "eslint-plugin-standard": "3.0.1",
-        "standard-engine": "7.0.0"
+        "eslint-config-standard-jsx": "4.0.2",
+        "eslint-plugin-import": "~2.2.0",
+        "eslint-plugin-node": "~4.2.2",
+        "eslint-plugin-promise": "~3.5.0",
+        "eslint-plugin-react": "~6.10.0",
+        "eslint-plugin-standard": "~3.0.1",
+        "standard-engine": "~7.0.0"
       }
     },
     "standard-engine": {
@@ -7511,10 +3609,10 @@
       "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
       "dev": true,
       "requires": {
-        "deglob": "2.1.0",
-        "get-stdin": "5.0.1",
-        "minimist": "1.2.0",
-        "pkg-conf": "2.0.0"
+        "deglob": "^2.1.0",
+        "get-stdin": "^5.0.1",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -7531,18 +3629,18 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.0.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -7550,7 +3648,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -7571,7 +3669,7 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "table": {
@@ -7580,14 +3678,20 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.0.0"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -7595,13 +3699,22 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7629,14 +3742,8 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -7644,13 +3751,14 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -7669,15 +3777,7 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "requires": {
-        "inherits": "2.0.3"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -7696,7 +3796,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -7716,7 +3816,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -30,23 +30,20 @@
     "url": "https://github.com/todogroup/repolinter.git"
   },
   "dependencies": {
-    "chai": "^4.0.2",
-    "chai-string": "^1.3.0",
     "find-config": "^1.0.0",
-    "fs": "0.0.1-security",
     "jsonfile": "^3.0.0",
     "log-symbols": "^1.0.2",
     "matched": "^0.4.4",
-    "npm": "^5.7.1",
-    "path": "^0.12.7",
     "rimraf": "^2.6.1",
     "simple-git": "^1.73.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {
+    "chai": "^4.0.2",
+    "chai-string": "^1.3.0",
     "mocha": "^3.4.2",
     "nyc": "^11.0.2",
     "sinon": "^4.1.2",
-    "standard": "^10.0.2"
+    "standard": "^10.0.3"
   }
 }


### PR DESCRIPTION
- chai, chai-string: moved to devDependencies
- fs: dropped (ships with node)
- npm: dropped (unused)
- path: dropped (ships with node)

This substantially decreases the install size from 93 MB to 1.4 MB when used as a dependency or via `npx`.