### PR TITLE
Add a rule for issue and pull request templates

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,0 +1,15 @@
+## Issue Report
+
+(A clear and concise description of the issue)
+
+## Expected Behavior
+
+(Write out the expected behavior here.)
+
+## Actual Behavior
+
+(Write out what actually happened here.)
+
+## Steps to Reproduce the Issue
+
+(Write out detailed steps to reproduce the issue here.)

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,20 @@
+<!--
+Thank you for sending the PR! We appreciate you spending the time to work on these changes.
+
+Help us understand your motivation by explaining why you decided to make this change.
+
+Happy contributing!
+
+-->
+
+## Motivation
+
+(Write your motivation here.)
+
+## Proposed Changes
+
+(Write out the details of your proposed changes here.)
+
+## Test Plan
+
+(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ npx repolinter
 ✔ integrates-with-ci: found (.travis.yml)
 ✔ source-license-headers-exist: The first 5 lines of 'index.js' contain all of the requested patterns.
 ...
+✔ github-issue-template-exists: found (ISSUE_TEMPLATE)
+✔ github-pull-request-template-exists: found (PULL_REQUEST_TEMPLATE)
 ✔ package-metadata-exists: found (Gemfile)
 ✔ package-metadata-exists: found (package.json)
 ```
@@ -103,6 +105,11 @@ Produces a failure for each file matching ```**/*.js,!node_modules/**``` option 
 ### test-directory-exists
 Fails if there isn't a directory matching ```test*``` or ```specs``` in the directory tree of the target directory.
 
+### github-issue-template-exists
+Fails if there isn't a file matching ```ISSUE_TEMPLATE*``` in the root of the target directory or under the ```.github``` directory. See https://blog.github.com/2016-02-17-issue-and-pull-request-templates/ for more details.
+
+### github-pull-request-template-exists
+Fails if there isn't a file matching ```PULL_REQUEST_TEMPLATE*``` in the root of the target directory or under the ```.github``` directory. See https://blog.github.com/2016-02-17-issue-and-pull-request-templates/ for more details.
 
 ## Configuring rules
 

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -24,7 +24,9 @@
           "human-readable-content": "email address"
         }
       ],
-      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"], "flags": "i"}]
+      "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"], "flags": "i"}],
+      "github-issue-template-exists:file-existence": ["error", {"files": ["ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE*"]}],
+      "github-pull-request-template-exists:file-existence": ["error", {"files": ["PULL_REQUEST_TEMPLATE*", ".github/PULL_REQUEST_TEMPLATE*"]}]
     },
     "language=javascript": {
       "package-metadata-exists:file-existence": ["error", {"files": ["package.json"]}]


### PR DESCRIPTION
Refer to issue #83 

Check if recommended templates exists in the root directory or under `.github`. The templates are `ISSUE_TEMPLATE*` and `PULL_REQUEST_TEMPLATE*`.

I tested locally and saw the failure messages first:

```
✖ github-issue-template-exists: not found: (ISSUE_TEMPLATE*, .github/ISSUE_TEMPLATE*)
✖ github-pull-request-template-exists: not found: (PULL_REQUEST_TEMPLATE*, .github/PULL_REQUEST_TEMPLATE*)
```

I then added sample template files and saw the successes. I tested adding the files in the root and under `.github`.

```
✔ github-issue-template-exists: found (ISSUE_TEMPLATE)
✔ github-pull-request-template-exists: found (.github/PULL_REQUEST_TEMPLATE)
```
