### PR TITLE
Implement rules in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Fails if Licensee doesn't detect the repository's license.
 
 This rule requires ```licensee``` in the path, see [command line dependencies](#command-line-dependencies) for details.
 
+## Implementing Rules
+
+Rules are written in JavaScript (see the rules/ directory for examples). A rule can also be written in JSON as a 'rule set' (i.e. a configuraton of rules) allowing rules to be composed from smaller items. The rules/apache-notice.json is an example of a rule implemented in JSON.
 
 ## License
 

--- a/rules/apache-notice.json
+++ b/rules/apache-notice.json
@@ -1,0 +1,13 @@
+{
+  "rules": {
+    "all": {
+      "notice-file-exists:file-existence": [
+        "error",
+        {
+          "files": ["NOTICE*"],
+          "fail-message": "The NOTICE file is described in section 4.4 of the Apache License version 2.0. Its presence is not mandated by the license itself, but by ASF policy."
+        }
+      ]
+    }
+  }
+}

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -41,13 +41,7 @@
       "license-detectable-by-licensee": ["error"]
     },
     "license=Apache-2.0": {
-      "notice-file-exists:file-existence": [
-        "error",
-        {
-          "files": ["NOTICE*"],
-          "fail-message": "The NOTICE file is described in section 4.4 of the Apache License version 2.0. Its presence is not mandated by the license itself, but by ASF policy."
-        }
-      ]
+      "notice-file-exists:apache-notice": ["error"]
     },
     "language=python": {
       "package-metadata-exists:file-existence": ["error", {"files": ["setup.py", "requirements.txt"]}]


### PR DESCRIPTION

## Motivation

Implements #103 so that rules can be implemented as rulesets in addition to in JavaScript. An example rule is implemented this way (apache-notice.json).

## Proposed Changes

Changes to index.js' execution engine so it recurses if it meets a .json rule file.

## Test Plan

I ran ./bin/repolinter.js and npm test locally.