### PR TITLE
Add alternative AppVeyor configuration file name

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -14,7 +14,12 @@
       "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}],
       "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": "true"}],
-      "integrates-with-ci:file-existence": ["error", {"files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile"]}],
+      "integrates-with-ci:file-existence": [
+        "error",
+        {
+          "files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", ".appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile"]
+        }
+      ],
       "code-of-conduct-file-contains-email:file-contents": [
         "error",
         {


### PR DESCRIPTION
AppVeyor alternatively supports configuration file names with a leading dot, see

https://www.appveyor.com/docs/build-configuration/#yaml-file-alternative-naming