### PR TITLE
Add support for non-existent files to file-contents module

### DIFF
--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -8,6 +8,11 @@ module.exports = function (fileSystem, rule) {
   const fs = options.fs || fileSystem
   const files = fs.findAll(options.files)
 
+  if (files.length === 0 && options['fail-on-non-existent']) {
+    const message = `not found: (${options.files.join(', ')})`
+    return [new Result(rule, message, options.files, false)]
+  }
+
   const results = files.map(file => {
     const fileContents = fs.getFileContents(file)
     const regexp = new RegExp(options.content, options.flags)

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -113,7 +113,7 @@ describe('rule', () => {
             },
             targetDir: '.'
           },
-          file: 'README.md',
+          files: ['README.md'],
           content: 'foo'
         }
       }

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -122,5 +122,36 @@ describe('rule', () => {
       const expected = []
       expect(actual).to.deep.equal(expected)
     })
+
+    it('returns failure if file does not exist with failure flag', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAll () {
+              return []
+            },
+            getFileContents () {
+
+            },
+            targetDir: '.'
+          },
+          files: ['README.md', 'READMOI.md'],
+          content: 'foo',
+          'fail-on-non-existent': true
+        }
+      }
+
+      const actual = fileContents(null, rule)
+      const expected = [
+        new Result(
+          rule,
+          'not found: (README.md, READMOI.md)',
+          ['README.md', 'READMOI.md'],
+          false
+        )
+      ]
+
+      expect(actual).to.deep.equal(expected)
+    })
   })
 })


### PR DESCRIPTION
The file content module does not return a Result object if no files exist. This patch makes the module return a failing Result object in that case if they use a 'fail-on-non-existent' flag in the options.