### PR TITLE
Make file-contents rule target more consistent

### DIFF
--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -10,7 +10,7 @@ module.exports = function (fileSystem, rule) {
 
   if (files.length === 0 && options['fail-on-non-existent']) {
     const message = `not found: (${options.files.join(', ')})`
-    return [new Result(rule, message, options.files, false)]
+    return [new Result(rule, message, null, false)]
   }
 
   const results = files.map(file => {

--- a/tests/rules/file_contents_tests.js
+++ b/tests/rules/file_contents_tests.js
@@ -146,7 +146,7 @@ describe('rule', () => {
         new Result(
           rule,
           'not found: (README.md, READMOI.md)',
-          ['README.md', 'READMOI.md'],
+          null,
           false
         )
       ]


### PR DESCRIPTION
I introduced a bug into repo linter in one of my previous commits

Basically, targets passed into Result objects are typically null
(https://github.com/todogroup/repolinter/blob/f11d2aaa4eb70c3f194e6c5a805de0a42ca08694/index.js#L80) or
a string. I passed in an array which is atypical. This patch instead
passes in null as the target because it matches nothing.


## Test Plan

$ node_modules/mocha/bin/mocha tests/rules/file_contents_tests.js