### PR TITLE
Make file-contents module only handle files

### DIFF
--- a/lib/file_system.js
+++ b/lib/file_system.js
@@ -26,9 +26,20 @@ class FileSystem {
     }
   }
 
-  findAll (globs, nocase) {
-    return glob.sync(globs, {cwd: this.targetDir, nocase: nocase})
+  findAllFiles (globs, nocase) {
+    return this.glob(
+      globs,
+      {cwd: this.targetDir, nocase: nocase, nodir: true}
+    )
+  }
+
+  glob (globs, options) {
+    return glob.sync(globs, options)
       .filter(relativePath => this.shouldInclude(relativePath))
+  }
+
+  findAll (globs, nocase) {
+    return this.glob(globs, {cwd: this.targetDir, nocase: nocase})
   }
 
   shouldInclude (path) {

--- a/rules/file-starts-with.js
+++ b/rules/file-starts-with.js
@@ -6,7 +6,7 @@ const Result = require('../lib/result')
 module.exports = function (fileSystem, rule) {
   const options = rule.options
   const fs = options.fs || fileSystem
-  const files = fs.findAll(options.files)
+  const files = fs.findAllFiles(options.files, options.nocase === true)
 
   let results = []
   files.forEach(file => {

--- a/tests/rules/file_starts_with_tests.js
+++ b/tests/rules/file_starts_with_tests.js
@@ -35,7 +35,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findAll () {
+            findAllFiles () {
               return ['somefile.js']
             },
             readLines () {
@@ -67,7 +67,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findAll () {
+            findAllFiles () {
               return []
             },
             targetDir: '.'


### PR DESCRIPTION
Fixing a bug in the `file-contents` module. Globbing patterns would include
directories. When we'd iterate over them, the code would try to open them and
'read their contents'. Being a directory, this would throw.
