### PR TITLE
Make file_not_contents rule return a success if no files are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Fails if the content of any of the files specified in the ```files``` option doe
 Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": "true"``` in the options for a case-insensitive search.
 
 ### file-not-contents
-The opposite of ```file-contents```.
+The opposite of ```file-contents```. By default, no output is returned if no file exists given the inputs. Use the ```succeed-on-non-existent``` option to return a success result.
 
 ### file-starts-with
 Produces a failure for each file matching the ```files``` option if the first ```lineCount``` lines don't match all of the regular expressions specified in the ```patterns``` option.

--- a/lib/file_system.js
+++ b/lib/file_system.js
@@ -26,9 +26,20 @@ class FileSystem {
     }
   }
 
-  findAll (globs, nocase) {
-    return glob.sync(globs, {cwd: this.targetDir, nocase: nocase})
+  findAllFiles (globs, nocase) {
+    return this.glob(
+      globs,
+      {cwd: this.targetDir, nocase: nocase, nodir: true}
+    )
+  }
+
+  glob (globs, options) {
+    return glob.sync(globs, options)
       .filter(relativePath => this.shouldInclude(relativePath))
+  }
+
+  findAll (globs, nocase) {
+    return this.glob(globs, {cwd: this.targetDir, nocase: nocase})
   }
 
   shouldInclude (path) {

--- a/rules/file-not-contents.js
+++ b/rules/file-not-contents.js
@@ -6,7 +6,12 @@ const Result = require('../lib/result')
 module.exports = function (fileSystem, rule) {
   const options = rule.options
   const fs = options.fs || fileSystem
-  const files = fs.findAll(options.files)
+  const files = fs.findAllFiles(options.files)
+
+  if (files.length === 0 && options['succeed-on-non-existent']) {
+    const message = `not found: (${options.files.join(', ')})`
+    return [new Result(rule, message, null, true)]
+  }
 
   const results = files.map(file => {
     const fileContents = fs.getFileContents(file)

--- a/rules/file-starts-with.js
+++ b/rules/file-starts-with.js
@@ -6,7 +6,7 @@ const Result = require('../lib/result')
 module.exports = function (fileSystem, rule) {
   const options = rule.options
   const fs = options.fs || fileSystem
-  const files = fs.findAll(options.files)
+  const files = fs.findAllFiles(options.files, options.nocase === true)
 
   let results = []
   files.forEach(file => {

--- a/tests/rules/file_not_contents_tests.js
+++ b/tests/rules/file_not_contents_tests.js
@@ -13,7 +13,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findAll () {
+            findAllFiles () {
               return ['README.md']
             },
             getFileContents () {
@@ -43,7 +43,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findAll () {
+            findAllFiles () {
               return ['README.md']
             },
             getFileContents () {
@@ -70,11 +70,41 @@ describe('rule', () => {
       expect(actual).to.deep.equal(expected)
     })
 
+    it('returns success if success flag enabled but file does not exist', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAllFiles () {
+              return []
+            },
+            getFileContents () {
+
+            },
+            targetDir: '.'
+          },
+          files: ['READMOI.md'],
+          content: 'foo',
+          'succeed-on-non-existent': true
+        }
+      }
+
+      const actual = fileContents(null, rule)
+      const expected = [
+        new Result(
+          rule,
+          'not found: (READMOI.md)',
+          null,
+          true
+        )
+      ]
+      expect(actual).to.deep.equal(expected)
+    })
+
     it('returns nothing if requested file does not exist', () => {
       const rule = {
         options: {
           fs: {
-            findAll () {
+            findAllFiles () {
               return []
             },
             getFileContents () {

--- a/tests/rules/file_starts_with_tests.js
+++ b/tests/rules/file_starts_with_tests.js
@@ -35,7 +35,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findAll () {
+            findAllFiles () {
               return ['somefile.js']
             },
             readLines () {
@@ -67,7 +67,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findAll () {
+            findAllFiles () {
               return []
             },
             targetDir: '.'


### PR DESCRIPTION

    1) This change, like #113, makes the rule only apply to files (instead of
    including directories
    2) Add an option to return a success if no file is found matching the target

Note:
This PR contains the contents from #113