### PR TITLE
Make README exists rule case insensitive and fix kludgy string linteral code and bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,13 @@ Package systems (for example Maven, NPM and PyPI) are detected by looking for ce
 The rules system is made up of rule types which can be customized to fit your needs.
 
 ### directory-existence
-Fails if none of the directories specified in the ```directories``` option exist. Pass in a ```fail-message``` option to further explain why the directory should exist to the user. Pass in ```"nocase": "true"``` in the options for a case-insensitive search.
+Fails if none of the directories specified in the ```directories``` option exist. Pass in a ```fail-message``` option to further explain why the directory should exist to the user. Pass in ```"nocase": true``` in the options for a case-insensitive search.
 
 ### file-contents
 Fails if the content of any of the files specified in the ```files``` option doesn't match the regular expression specified in the ```content``` option. If the content is a regular expression or some other non-human-readable string, include the ```human-readable-content``` option with human-readable output. By default, no output is returned if no file exists given the inputs. Use the ```fail-on-non-existent``` option to return a failure.
 
 ### file-existence
-Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": "true"``` in the options for a case-insensitive search.
+Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": true``` in the options for a case-insensitive search.
 
 ### file-not-contents
 The opposite of ```file-contents```. By default, no output is returned if no file exists given the inputs. Use the ```succeed-on-non-existent``` option to return a success result.

--- a/lib/file_system.js
+++ b/lib/file_system.js
@@ -20,8 +20,15 @@ class FileSystem {
     return this.filterPaths.filter(filter => filter.endsWith('/'))
   }
 
-  findFirst (globs) {
-    const allFiles = this.findAll(globs)
+  findFirst (globs, nocase) {
+    const allFiles = this.findAll(globs, nocase)
+    if (allFiles.length > 0) {
+      return allFiles[0]
+    }
+  }
+
+  findFirstFile (globs, nocase) {
+    const allFiles = this.findAllFiles(globs, nocase)
     if (allFiles.length > 0) {
       return allFiles[0]
     }
@@ -30,7 +37,7 @@ class FileSystem {
   findAllFiles (globs, nocase) {
     return this.glob(
       globs,
-      {cwd: this.targetDir, nocase: nocase, nodir: true}
+      {cwd: this.targetDir, nocase: !!nocase, nodir: true}
     )
   }
 
@@ -40,7 +47,7 @@ class FileSystem {
   }
 
   findAll (globs, nocase) {
-    return this.glob(globs, {cwd: this.targetDir, nocase: nocase})
+    return this.glob(globs, {cwd: this.targetDir, nocase: !!nocase})
   }
 
   isBinaryFile (relativeFile, lineCount) {

--- a/rules/file-existence.js
+++ b/rules/file-existence.js
@@ -6,7 +6,7 @@ const Result = require('../lib/result')
 module.exports = function (fileSystem, rule) {
   const options = rule.options
   const fs = options.fs || fileSystem
-  const file = fs.findFirst(options.files, options.nocase === 'true')
+  const file = fs.findFirstFile(options.files, options.nocase)
 
   const passed = !!file
   const message = (() => {

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -7,7 +7,7 @@
   "rules": {
     "all": {
       "license-file-exists:file-existence": ["error", {"files": ["LICENSE*", "COPYING*"]}],
-      "readme-file-exists:file-existence": ["error", {"files": ["README*"]}],
+      "readme-file-exists:file-existence": ["error", {"files": ["README*"], "nocase": true}],
       "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIB*"]}],
       "code-of-conduct-file-exists:file-existence": ["error", {"files": ["CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT*"]}],
       "support-file-exists:file-existence": ["error", {"files": ["SUPPORT*"], "nocase": true}],

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -10,10 +10,10 @@
       "readme-file-exists:file-existence": ["error", {"files": ["README*"]}],
       "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIB*"]}],
       "code-of-conduct-file-exists:file-existence": ["error", {"files": ["CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT*"]}],
-      "support-file-exists:file-existence": ["error", {"files": ["SUPPORT*"], "nocase": "true"}],
+      "support-file-exists:file-existence": ["error", {"files": ["SUPPORT*"], "nocase": true}],
       "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}],
-      "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": "true"}],
+      "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": true}],
       "integrates-with-ci:file-existence": [
         "error",
         {

--- a/tests/rules/file_existence_tests.js
+++ b/tests/rules/file_existence_tests.js
@@ -13,7 +13,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findFirst () {
+            findFirstFile () {
               return 'LICENSE.md'
             },
             targetDir: '.'
@@ -41,7 +41,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findFirst (dontcare, nocase) {
+            findFirstFile (dontcare, nocase) {
               expect(nocase).to.equal(true)
               return 'LICENSE.md'
             },
@@ -49,7 +49,7 @@ describe('rule', () => {
           },
           files: ['lIcEnSe*'],
           name: 'License file',
-          nocase: 'true'
+          nocase: true
         }
       }
 
@@ -71,7 +71,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findFirst () {
+            findFirstFile () {
             },
             targetDir: '.'
           },
@@ -98,7 +98,7 @@ describe('rule', () => {
       const rule = {
         options: {
           fs: {
-            findFirst () {
+            findFirstFile () {
             },
             targetDir: '.'
           },


### PR DESCRIPTION
Some repos have `Readme.md`. GitHub still recognized it as a
readme file. So should repolinter


Also `nocase` was expected to be the string `'true'` string literal. That was
a bit kludgy. Now it accepts any truthy value.

In fs, nocase wasn't being passed into findall