### PR TITLE
[oss] Making findAllFiles ignore symlinks for **

### DIFF
--- a/lib/file_system.js
+++ b/lib/file_system.js
@@ -35,10 +35,23 @@ class FileSystem {
   }
 
   findAllFiles (globs, nocase) {
-    return this.glob(
+    const symlinks = {}
+    const filePaths = this.glob(
       globs,
-      {cwd: this.targetDir, nocase: !!nocase, nodir: true}
+      {cwd: this.targetDir, nocase: !!nocase, nodir: true, symlinks}
     )
+
+    // Make symlinks relative
+    const onlySymlinks = {}
+    for (const fullPath in symlinks) {
+      if (symlinks[fullPath]) {
+        const relativeToRepoPath = path.relative(this.targetDir, fullPath)
+        onlySymlinks[relativeToRepoPath] = true
+      }
+    }
+
+    // Remove all symlinks
+    return filePaths.filter(filePath => !onlySymlinks[filePath])
   }
 
   glob (globs, options) {

--- a/tests/lib/file_system_tests.js
+++ b/tests/lib/file_system_tests.js
@@ -9,6 +9,17 @@ describe('lib', () => {
   describe('file_system', () => {
     const FileSystem = require('../../lib/file_system')
 
+    describe('findAllFiles', () => {
+      it('should ignore symlinks for ** globs', () => {
+        const symlink = './tests/lib/symlink_for_test'
+        const stats = require('fs').lstatSync(symlink)
+        expect(stats.isSymbolicLink()).to.equal(true)
+        const fs = new FileSystem(path.resolve('./tests'))
+        const files = fs.findAllFiles('**/lib/symlink_for_test')
+        expect(files).to.have.lengthOf(0)
+      })
+    })
+
     describe('findAll', () => {
       it('should honor filtered directories', () => {
         const includedDirectories = ['lib/', 'rules/']

--- a/tests/lib/symlink_for_test
+++ b/tests/lib/symlink_for_test
@@ -1,0 +1,1 @@
+file_system_tests.js


### PR DESCRIPTION
This was making the file not contents module fail because a path was
being returned (the symlink) but opening it to read the symlink's
contents would return undefined
