### PR TITLE
Fixed link to source-license-headers-exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ All languages:
 * [license-detectable-by-licensee](#license-detectable-by-licensee)
 * [test-directory-exists](#test-directory-exists)
 * [integrates-with-ci](#integrates-with-ci)
-* [source-license-headers-exist]([#source-license-headers-exist)
+* [source-license-headers-exist](#source-license-headers-exist)
 
 ### license-file-exists
 Fails if there isn't a file matching ```LICENSE*``` or ```COPYING*``` in the root of the target directory.


### PR DESCRIPTION
* README.md was not properly referencing to anchor for source-license-headers-exist section
* Fixed link by removing superfluous [ character

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

Fixing source-license-headers-exist link in documentation which currently results in a 404

## Proposed Changes

* Fixed link by removing superfluous [ character

## Test Plan

* Click on source-license-headers-exist link from rendered README.md and check whether the link now works

