### PR TITLE
Many changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Fails if none of the files specified in the ```files``` option exist. Pass in a 
 The opposite of ```file-contents```. By default, no output is returned if no file exists given the inputs. Use the ```succeed-on-non-existent``` option to return a success result.
 
 ### file-starts-with
-Produces a failure for each file matching the ```files``` option if the first ```lineCount``` lines don't match all of the regular expressions specified in the ```patterns``` option. Set the ```skip-binary-files``` option to skip files that aren't text. By default, no output is returned if no file exists given the inputs. In that case, use the ```succeed-on-non-existent``` option to return a success result.
+Produces a failure for each file matching the ```files``` option if the first ```lineCount``` lines don't match all of the regular expressions specified in the ```patterns``` option. Set the ```skip-binary-files``` option to skip files that aren't text. By default, no output is returned if no file exists given the inputs. In that case, use the ```succeed-on-non-existent``` option to return a success result. Certain files can be omitted from being checked by using the ```skip-paths-matching``` option as an object with `extensions` and `patterns` array members.
 
 ### file-type-exclusion
 Fails if any files match the ```type``` option.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Fails if none of the files specified in the ```files``` option exist. Pass in a 
 The opposite of ```file-contents```. By default, no output is returned if no file exists given the inputs. Use the ```succeed-on-non-existent``` option to return a success result.
 
 ### file-starts-with
-Produces a failure for each file matching the ```files``` option if the first ```lineCount``` lines don't match all of the regular expressions specified in the ```patterns``` option. Set the ```skip-binary-files``` option to skip files that aren't text.
+Produces a failure for each file matching the ```files``` option if the first ```lineCount``` lines don't match all of the regular expressions specified in the ```patterns``` option. Set the ```skip-binary-files``` option to skip files that aren't text. By default, no output is returned if no file exists given the inputs. In that case, use the ```succeed-on-non-existent``` option to return a success result.
 
 ### file-type-exclusion
 Fails if any files match the ```type``` option.

--- a/lib/file_system.js
+++ b/lib/file_system.js
@@ -35,10 +35,23 @@ class FileSystem {
   }
 
   findAllFiles (globs, nocase) {
-    return this.glob(
+    const symlinks = {}
+    const filePaths = this.glob(
       globs,
-      {cwd: this.targetDir, nocase: !!nocase, nodir: true}
+      {cwd: this.targetDir, nocase: !!nocase, nodir: true, symlinks}
     )
+
+    // Make symlinks relative
+    const onlySymlinks = {}
+    for (const fullPath in symlinks) {
+      if (symlinks[fullPath]) {
+        const relativeToRepoPath = path.relative(this.targetDir, fullPath)
+        onlySymlinks[relativeToRepoPath] = true
+      }
+    }
+
+    // Remove all symlinks
+    return filePaths.filter(filePath => !onlySymlinks[filePath])
   }
 
   glob (globs, options) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "standard --env mocha && mocha tests/**/*.js --no-timeouts",
-    "coverage": "nyc npm test"
+    "coverage": "nyc npm test",
+    "fix": "standard --fix"
   },
   "keywords": [
     "lint",

--- a/rules/file-starts-with.js
+++ b/rules/file-starts-with.js
@@ -13,6 +13,27 @@ module.exports = function (fileSystem, rule) {
     filteredFiles = filteredFiles.filter(file => !fs.isBinaryFile(file))
   }
 
+  if (options['skip-paths-matching']) {
+    let regexes = []
+    const extensions = options['skip-paths-matching']['extensions']
+    if (extensions && extensions.length > 0) {
+      const extJoined = extensions.join('|')
+      // \.(svg|png|exe)$
+      regexes.push(new RegExp('\.(' + extJoined + ')$', 'i')) // eslint-disable-line no-useless-escape
+    }
+
+    const patterns = options['skip-paths-matching']['patterns']
+    if (patterns && patterns.length > 0) {
+      const filteredPatterns = patterns
+        .filter(p => typeof p === 'string' && p !== '')
+        .map(p => new RegExp(p, options['skip-paths-matching']['flags']))
+      regexes = regexes.concat(filteredPatterns)
+    }
+    filteredFiles = filteredFiles.filter(file =>
+      !regexes.some(regex => file.match(regex))
+    )
+  }
+
   if (filteredFiles.length === 0 && options['succeed-on-non-existent']) {
     const message = `not found: (${options.files.join(', ')})`
     return [new Result(rule, message, null, true)]

--- a/rules/file-starts-with.js
+++ b/rules/file-starts-with.js
@@ -13,6 +13,11 @@ module.exports = function (fileSystem, rule) {
     filteredFiles = filteredFiles.filter(file => !fs.isBinaryFile(file))
   }
 
+  if (filteredFiles.length === 0 && options['succeed-on-non-existent']) {
+    const message = `not found: (${options.files.join(', ')})`
+    return [new Result(rule, message, null, true)]
+  }
+
   let results = []
   filteredFiles.forEach(file => {
     const lines = fs.readLines(file, options.lineCount)

--- a/tests/lib/file_system_tests.js
+++ b/tests/lib/file_system_tests.js
@@ -9,6 +9,17 @@ describe('lib', () => {
   describe('file_system', () => {
     const FileSystem = require('../../lib/file_system')
 
+    describe('findAllFiles', () => {
+      it('should ignore symlinks for ** globs', () => {
+        const symlink = './tests/lib/symlink_for_test'
+        const stats = require('fs').lstatSync(symlink)
+        expect(stats.isSymbolicLink()).to.equal(true)
+        const fs = new FileSystem(path.resolve('./tests'))
+        const files = fs.findAllFiles('**/lib/symlink_for_test')
+        expect(files).to.have.lengthOf(0)
+      })
+    })
+
     describe('findAll', () => {
       it('should honor filtered directories', () => {
         const includedDirectories = ['lib/', 'rules/']

--- a/tests/lib/symlink_for_test
+++ b/tests/lib/symlink_for_test
@@ -1,0 +1,1 @@
+file_system_tests.js

--- a/tests/rules/file_starts_with_tests.js
+++ b/tests/rules/file_starts_with_tests.js
@@ -108,6 +108,35 @@ describe('rule', () => {
       expect(actual).to.deep.equal(expected)
     })
 
+    it('skips files with the `skip-paths-matching` option', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAllFiles () {
+              return ['Skip/paBle-path.js', 'afile.js', 'badextension.sVg']
+            },
+            readLines () {
+              return 'some javascript code'
+            },
+            targetDir: '.'
+          },
+          files: ['*'],
+          lineCount: 1,
+          patterns: ['some'],
+          'skip-paths-matching': {
+            extensions: ['bmp', 'svg'],
+            patterns: ['skip/pable', 'another-pattern-to-skip'],
+            flags: 'i'
+          }
+        }
+      }
+
+      const actual = fileStartsWith(null, rule)
+
+      expect(actual.length).to.equal(1)
+      expect(actual[0].target).to.equal('afile.js')
+    })
+
     it('returns an empty list if the request files don\'t exist', () => {
       const rule = {
         options: {

--- a/tests/rules/file_starts_with_tests.js
+++ b/tests/rules/file_starts_with_tests.js
@@ -77,6 +77,37 @@ describe('rule', () => {
       expect(actual.length).to.equal(0)
     })
 
+    it('returns a single result when glob has no matches and has succeed-on-non-existent option', () => {
+      const rule = {
+        options: {
+          fs: {
+            findAllFiles () {
+              return []
+            },
+            targetDir: '.'
+          },
+          files: ['*'],
+          lineCount: 1,
+          patterns: ['something-unmatchable'],
+          'succeed-on-non-existent': true
+        }
+      }
+
+      const expected = [
+        new Result(
+          rule,
+          'not found: (*)',
+          null,
+          true
+        )
+      ]
+
+      const actual = fileStartsWith(null, rule)
+
+      expect(actual.length).to.equal(1)
+      expect(actual).to.deep.equal(expected)
+    })
+
     it('returns an empty list if the request files don\'t exist', () => {
       const rule = {
         options: {


### PR DESCRIPTION
Kinda a grab bag of things: See commit descriptions for details.

Adding succeed-on-non-existent to file-starts-rule
Add `npm fix` command for simple standard js linter fixes
Ignoring paths and extensions for `file-starts-with` module 