### PR TITLE
This adds .drone.yml to integrates-with-ci default rulesets

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -17,7 +17,7 @@
       "integrates-with-ci:file-existence": [
         "error",
         {
-          "files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", ".appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile"]
+          "files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", ".appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile", ".drone.yml"]
         }
       ],
       "code-of-conduct-file-contains-email:file-contents": [


### PR DESCRIPTION

## Motivation

Would like to add check for Drone CI/CD into default ruleset.

## Proposed Changes

This only changes rulesets/default/json

## Test Plan

no code changes