### PR TITLE
adding standard env variable to deal with mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "coverage": "nyc npm test",
     "fix": "standard --fix"
   },
+  "standard": {
+    "env": [ "mocha" ]
+  },
   "keywords": [
     "lint",
     "linter",


### PR DESCRIPTION
Now, we can do `yarn test` without getting `'describe' is not defined.` errors