### PR TITLE
Add Dockerfile to support running in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.5 as ruby-deps
+FROM ruby:2.5.1-slim as ruby-deps
 
-ENV BUILD_DEPS cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev
+ENV BUILD_DEPS make build-essential cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y $BUILD_DEPS && \
@@ -9,7 +9,8 @@ RUN apt-get update && \
     apt-get remove -y $BUILD_DEPS
 # TODO: also remove unneeded transient dependencies
 
-FROM node:latest
+
+FROM node:10-slim
 
 # Copy Ruby dependencies
 COPY --from=ruby-deps . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME"
 ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
 
-RUN which licensee
-RUN which github-linguist
-
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --production

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #
 FROM ruby:2.5.1-slim as ruby-deps
 
-ENV RUNTIME_DEPS git
+ENV RUNTIME_DEPS git libicu57
 ENV BUILD_DEPS make build-essential cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev
 
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
+# To build:
+#
+#   docker build -t repolinter .
+#
+# To run against the current directory:
+#
+#   docker run -t -v $PWD:/src repolinter
+#
+# To run against a remote GitHub repository
+#
+#   docker run -t repolinter --git https://github.com/username/repo.git
+#
 FROM ruby:2.5.1-slim as ruby-deps
 
+ENV RUNTIME_DEPS git
 ENV BUILD_DEPS make build-essential cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y $BUILD_DEPS && \
+    apt-get install --no-install-recommends -y $RUNTIME_DEPS $BUILD_DEPS && \
     gem install --no-document licensee github-linguist && \
     apt-get remove -y $BUILD_DEPS && \
     apt-get autoremove -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ ENV BUILD_DEPS make build-essential cmake pkg-config libicu-dev zlib1g-dev libcu
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y $BUILD_DEPS && \
-    gem install licensee github-linguist && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get remove -y $BUILD_DEPS
-# TODO: also remove unneeded transient dependencies
+    gem install --no-document licensee github-linguist && \
+    apt-get remove -y $BUILD_DEPS && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 
 FROM node:10-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:2.5 as ruby-deps
+
+ENV BUILD_DEPS cmake pkg-config libicu-dev zlib1g-dev libcurl4-openssl-dev libssl-dev
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y $BUILD_DEPS && \
+    gem install licensee github-linguist && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get remove -y $BUILD_DEPS
+# TODO: also remove unneeded transient dependencies
+
+FROM node:latest
+
+# Copy Ruby dependencies
+COPY --from=ruby-deps . .
+
+# Copy ENV from Ruby image
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME"
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+
+RUN which licensee
+RUN which github-linguist
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+
+ENTRYPOINT ["node", "/app/bin/repolinter.js"]

--- a/lib/linguist.js
+++ b/lib/linguist.js
@@ -11,12 +11,15 @@ class Linguist {
    * Throws 'Linguist not installed' error if command line of 'linguist' is not available.
    */
   identifyLanguagesSync (targetDir) {
-    const linguistOutput = spawnSync('linguist', [targetDir, '--json']).stdout
-    if (linguistOutput == null) {
-      throw new Error('Linguist not installed')
+    // Command was renamed in https://github.com/github/linguist/pull/4208
+    for (const command of ['github-linguist', 'linguist']) {
+      const output = spawnSync(command, [targetDir, '--json']).stdout
+      if (output !== null) {
+        return JSON.parse(output.toString())
+      }
     }
-    const json = linguistOutput.toString()
-    return JSON.parse(json)
+
+    throw new Error('Linguist not installed')
   }
 }
 


### PR DESCRIPTION
## Motivation

Between Licensee and Linguist, there are a lot of dependencies needed to get `repolinter` working to its fullest potential.

## Proposed Changes

This PR adds a `Dockerfile` which builds both the Ruby and Node dependencies.

Usage:

```
$ docker run -it -v $PWD:/src -w /src bkeepers/repolinter
Target directory: /src
Ruleset: repolint.json
Linguist Axiom: Linguist not found in path, only running language-independent rules
✔ license-file-exists: found (LICENSE)
✔ readme-file-exists: found (README.md)
✔ contributing-file-exists: found (CONTRIBUTING.md)
✔ code-of-conduct-file-exists: found (CODE_OF_CONDUCT.md)
✔ readme-references-license: File README.md contains license
✔ binaries-not-present: Excluded file type doesn't exist (**/*.exe,**/*.dll,!node_modules/**)
✔ test-directory-exists: found (script/test)
✔ integrates-with-ci: found (.github/main.workflow)
✔ code-of-conduct-file-contains-email: File CODE_OF_CONDUCT.md contains email address
⚠ github-issue-template-exists: not found: (ISSUE_TEMPLATE*, .github/ISSUE_TEMPLATE*)
⚠ github-pull-request-template-exists: not found: (PULL_REQUEST_TEMPLATE*, .github/PULL_REQUEST_TEMPLATE*)
✔ license-detectable-by-licensee: Licensee identified the license for project: MIT
```

## Test Plan

Ideally, you could [build and run the tests via Docker on Travis CI](https://docs.travis-ci.com/user/docker/).

## TODO:

- [x] Reduce the size of the built image
- [x] Docs on using via docker