### PR TITLE
Fix linguist since command has been renamed

### DIFF
--- a/lib/linguist.js
+++ b/lib/linguist.js
@@ -11,12 +11,15 @@ class Linguist {
    * Throws 'Linguist not installed' error if command line of 'linguist' is not available.
    */
   identifyLanguagesSync (targetDir) {
-    const linguistOutput = spawnSync('linguist', [targetDir, '--json']).stdout
-    if (linguistOutput == null) {
-      throw new Error('Linguist not installed')
+    // Command was renamed in https://github.com/github/linguist/pull/4208
+    for (const command of ['github-linguist', 'linguist']) {
+      const output = spawnSync(command, [targetDir, '--json']).stdout
+      if (output !== null) {
+        return JSON.parse(output.toString())
+      }
     }
-    const json = linguistOutput.toString()
-    return JSON.parse(json)
+
+    throw new Error('Linguist not installed')
   }
 }
 


### PR DESCRIPTION
## Motivation

The linguist command was renamed from `linguist` to `github-linguist` in https://github.com/github/linguist/pull/4208.

## Proposed Changes

This updates linguist support to attempt to run both commands, returning the first one that succeeds.

## Test Plan

There do not appear to be tests for the current linguist support. I've tested it locally that this works with the latest version of linguist.