### PR TITLE
adding directories in which to find CONTRIBUTING, SUPPORT and COC files

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -8,10 +8,10 @@
     "all": {
       "license-file-exists:file-existence": ["error", {"files": ["LICENSE*", "COPYING*"]}],
       "readme-file-exists:file-existence": ["error", {"files": ["README*"], "nocase": true}],
-      "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIB*"]}],
-      "code-of-conduct-file-exists:file-existence": ["error", {"files": ["CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT*"]}],
+      "contributing-file-exists:file-existence": ["error", {"files": ["{docs/,.github/,}CONTRIB*"]}],
+      "code-of-conduct-file-exists:file-existence": ["error", {"files": ["{docs/,.github/,}CODEOFCONDUCT*", "{docs/,.github/,}CODE[-_]OF[-_]CONDUCT*"]}],
       "changelog-file-exists:file-existence": ["error", {"files": ["CHANGELOG*"], "nocase": true}],
-      "support-file-exists:file-existence": ["error", {"files": ["SUPPORT*"], "nocase": true}],
+      "support-file-exists:file-existence": ["error", {"files": ["{docs/,.github/,}SUPPORT*"], "nocase": true}],
       "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}],
       "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": true}],


### PR DESCRIPTION
Adding support for root, `.github`, and `docs` as a location for support
contributing, and code of conducts files. GitHub supports these

See
https://help.github.com/articles/setting-guidelines-for-repository-contributors/
https://help.github.com/articles/adding-support-resources-to-your-project/
https://help.github.com/articles/adding-a-code-of-conduct-to-your-project/
