### PR TITLE
Fix github-linguist finding on Windows

### DIFF
--- a/lib/linguist.js
+++ b/lib/linguist.js
@@ -1,6 +1,7 @@
 // Copyright 2017 TODO Group. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const isWindows = require('is-windows')
 const spawnSync = require('child_process').spawnSync
 
 class Linguist {
@@ -13,7 +14,7 @@ class Linguist {
   identifyLanguagesSync (targetDir) {
     // Command was renamed in https://github.com/github/linguist/pull/4208
     for (const command of ['github-linguist', 'linguist']) {
-      const output = spawnSync(command, [targetDir, '--json']).stdout
+      const output = spawnSync(isWindows() ? `${command}.bat` : command, [targetDir, '--json']).stdout
       if (output !== null) {
         return JSON.parse(output.toString())
       }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

repolinter couldn't find github-linguist despite github-linguist being installed...because Windows.

## Proposed Changes

Use the `isWindows()` method from the (working) licensee finding code to make this work on Windows.

## Test Plan

Run repolinter without the patch and note the `Linguist Axiom: Linguist not found in path, only running language-independent rules` message in the results. Check that Linguist was indeed installed (I used `gem list | grep linguist` in Git Bash on Windows 10).

Now add the patch, rerun repolinter, rejoice because the error is gone...and the notable lag time means github-linguist is doing its job. 😉 