### PR TITLE
Support GH Actions and Azure in the default integrates-with-ci rule

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -23,7 +23,18 @@
       "integrates-with-ci:file-existence": [
         "error",
         {
-          "files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", ".appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile", ".drone.yml"]
+          "files": [
+            ".gitlab-ci.yml", 
+            ".travis.yml", 
+            "appveyor.yml", 
+            ".appveyor.yml", 
+            "circle.yml", 
+            ".circleci/config.yml", 
+            "Jenkinsfile", 
+            ".drone.yml",
+            ".github/workflows/*",
+            "azure-pipelines.yml"
+          ]
         }
       ],
       "code-of-conduct-file-contains-email:file-contents": [


### PR DESCRIPTION
## Motivation

These are two major CI platforms that are not currently recognized by repolinter.

## Test Plan

Manually ran repolinter on a repository that has GitHub Actions configured.
