### PR TITLE
Added Github Actions to the default ruleset

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -23,7 +23,7 @@
       "integrates-with-ci:file-existence": [
         "error",
         {
-          "files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", ".appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile", ".drone.yml"]
+          "files": [".gitlab-ci.yml", ".travis.yml", "appveyor.yml", ".appveyor.yml", "circle.yml", ".circleci/config.yml", "Jenkinsfile", ".drone.yml", ".github/workflows/*.yml"]
         }
       ],
       "code-of-conduct-file-contains-email:file-contents": [


### PR DESCRIPTION
Hi,

## Motivation

This PR adds Github Actions to the default ruleset configuration for integration with CI platforms.

## Proposed Changes

GitHub Actions are stored in YML format in the `.github/workflows/` directory, the proposed change looks for presence of one or more .yml files in that directory.

## Test Plan

Can be tested by simply running repolinter against a repository containing github actions.

```✔ integrates-with-ci: found (.github/workflows/lint-test.yml)```
