### PR TITLE
Add file-hash rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ Fails if the content of any of the files specified in the ```files``` option doe
 ### file-existence
 Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": true``` in the options for a case-insensitive search.
 
+### file-hash
+Fails if the content of file specified in the ```file``` option does not produce the hex value in the ```hash``` option.  The default algorithm is ```sha256``` and can be changed in the ```algorithm``` option. Use the ```succeed-on-non-existent``` option if a missing file is acceptable, otherwise a missing file produces a failure.
+
 ### file-not-contents
 The opposite of ```file-contents```. By default, no output is returned if no file exists given the inputs. Use the ```succeed-on-non-existent``` option to return a success result.
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Fails if the content of any of the files specified in the ```files``` option doe
 Fails if none of the files specified in the ```files``` option exist. Pass in a ```fail-message``` option to further explain why the file should exist to the user. Pass in ```"nocase": true``` in the options for a case-insensitive search.
 
 ### file-hash
-Fails if the content of file specified in the ```file``` option does not produce the hex value in the ```hash``` option.  The default algorithm is ```sha256``` and can be changed in the ```algorithm``` option. Use the ```succeed-on-non-existent``` option if a missing file is acceptable, otherwise a missing file produces a failure.
+Fails if the content of file specified in the ```file``` option does not hash to the hex value in the ```hash``` option.  The default algorithm is ```sha256``` and can be changed in the ```algorithm``` option. Use the ```succeed-on-non-existent``` option if a missing file is acceptable, otherwise a missing file produces a failure.
 
 ### file-not-contents
 The opposite of ```file-contents```. By default, no output is returned if no file exists given the inputs. Use the ```succeed-on-non-existent``` option to return a success result.

--- a/rules/file-hash.js
+++ b/rules/file-hash.js
@@ -1,0 +1,38 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const Result = require('../lib/result')
+const crypto = require('crypto');
+
+module.exports = function (fileSystem, rule) {
+  const options = rule.options
+  const fs = options.fs || fileSystem
+  const file = fs.findFirstFile(options.file)
+
+  if (file === undefined ) {
+    const message = `not found: ${options.file}`
+    let status = options['succeed-on-non-existent']
+    if (status === undefined) {
+      status = false;
+    }
+    return [new Result(rule, message, null, status)]
+  }
+
+  let algorithm = options['algorithm'];
+  if (algorithm === undefined) {
+    algorithm = 'sha256'
+  }
+  const digester = crypto.createHash(algorithm)
+
+  let fileContents = fs.getFileContents(file)
+  if (fileContents === undefined) {
+    fileContents = ''
+  }
+  digester.update(fileContents)
+  const hash = digester.digest('hex');
+
+  const passed = hash == options['hash']
+  const message = `File ${file} ${passed ? 'matches hash' : 'doesn\'t match hash'}`
+
+  return [new Result(rule, message, file, passed)]
+}

--- a/tests/rules/file_hash_tests.js
+++ b/tests/rules/file_hash_tests.js
@@ -1,0 +1,166 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const chai = require('chai')
+const expect = chai.expect
+const Result = require('../../lib/result')
+const FileSystem = require('../../lib/file_system')
+
+describe('rule', () => {
+  describe('files_hash', () => {
+    const fileContents = require('../../rules/file-hash')
+
+    it('returns passes if requested file matches the hash', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirstFile () {
+              return 'README.md'
+            },
+            getFileContents () {
+              return 'foo'
+            },
+            targetDir: '.'
+          },
+          file: 'README.md',
+          hash: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae'
+        }
+      }
+
+      const expected = [
+        new Result(
+          rule,
+          'File README.md matches hash',
+          'README.md',
+          true
+        )
+      ]
+
+      const actual = fileContents(null, rule)
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns passes if requested file contents exists different algorithm', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirstFile () {
+              return 'README.md'
+            },
+            getFileContents () {
+              return 'foo'
+            },
+            targetDir: '.'
+          },
+          file: 'README.md',
+          algorithm: 'sha512',
+          hash: 'f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7'
+        }
+      }
+
+      const expected = [
+        new Result(
+          rule,
+          'File README.md matches hash',
+          'README.md',
+          true
+        )
+      ]
+
+      const actual = fileContents(null, rule)
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns fails if requested file does not match', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirstFile () {
+              return 'README.md'
+            },
+            getFileContents () {
+              return 'foo'
+            },
+            targetDir: '.'
+          },
+          file: ['README.md'],
+          hash: 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+        }
+      }
+
+      const expected = [
+        new Result(
+          rule,
+          'File README.md doesn\'t match hash',
+          'README.md',
+          false
+        )
+      ]
+
+      const actual = fileContents(null, rule)
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns failure if requested file does not exist', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirstFile () {
+              return undefined
+            },
+            getFileContents () {
+
+            },
+            targetDir: '.'
+          },
+          file: 'README.md',
+          content: 'foo'
+        }
+      }
+
+      const actual = fileContents(null, rule)
+      const expected = [
+        new Result(
+          rule,
+          'not found: README.md',
+          null,
+          false
+        )
+      ]
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('returns success if file does not exist with success flag', () => {
+      const rule = {
+        options: {
+          fs: {
+            findFirstFile () {
+              return undefined
+            },
+            getFileContents () {
+
+            },
+            targetDir: '.'
+          },
+          file: 'README.md',
+          content: 'foo',
+          'succeed-on-non-existent': true
+        }
+      }
+
+      const actual = fileContents(null, rule)
+      const expected = [
+        new Result(
+          rule,
+          'not found: README.md',
+          null,
+          true
+        )
+      ]
+
+      expect(actual).to.deep.equal(expected)
+    })
+
+  })
+})


### PR DESCRIPTION
Add a rule that checks to see if a file matches a hash.

This is useful for projects that specify exact files, such as the Apache
license, in a specific place with specific content.  Much better than
making a giant glob out of the contents.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

Allow entire static file contents to be checked efficiently.  Globs can be used but are quite obtuse when we enter the multi-kilobyte range.

## Proposed Changes

Add a `file-hash` rule.  Options are `file`, `hash`, `algorithm`, and `succeed-on-non-existent`.  

`file` and `hash` have no default, that is required for each rule.  `file` is like other uses. `hash` is the hex representation of the hash. 

`algorithm` defaults to `sha256`.  The hash algorithm to use.  Any node crypto value can be used.

`succeeds-on-non-existent` defaults to false.  If we are looking for a hash we really want the file to exist normally.

## Test Plan

Mostly the same tests as file-not-exist, via mocha.
