### PR TITLE
Support docs and .github folders

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -9,13 +9,12 @@
       "license-file-exists:file-existence": ["error", {"files": ["LICENSE*", "COPYING*"], "nocase": true}],
       "readme-file-exists:file-existence": ["error", {"files": ["README*"], "nocase": true}],
 
-      "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIB*", ".github/CONTRIB*"]}],
+      "contributing-file-exists:file-existence": ["error", {"files": ["{docs/,.github/,}CONTRIB*"]}],
       "code-of-conduct-file-exists:file-existence": ["error", {"files": [
-        "CODEOFCONDUCT*", "CODE-OF-CONDUCT*", "CODE_OF_CONDUCT*",
-        ".github/CODEOFCONDUCT*", ".github/CODE-OF-CONDUCT*", ".github/CODE_OF_CONDUCT*"
+        "{docs/,.github/,}CODEOFCONDUCT*", "{docs/,.github/,}CODE-OF-CONDUCT*", "{docs/,.github/,}CODE_OF_CONDUCT*"
         ]}],
       "changelog-file-exists:file-existence": ["error", {"files": ["CHANGELOG*"], "nocase": true}],
-      "security-file-exists:file-existence": ["error", {"files": ["SECURITY.md"]}],
+      "security-file-exists:file-existence": ["error", {"files": ["{docs/,.github/,}SECURITY.md"]}],
       "support-file-exists:file-existence": ["error", {"files": ["{docs/,.github/,}SUPPORT*"], "nocase": true}],
       "readme-references-license:file-contents": ["error", {"files": ["README*"], "content": "license", "flags": "i"}],
       "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}],


### PR DESCRIPTION
## Motivation

The GitHub guidelines specify that some files can be located inany of the following places:
- the root of the repository
- the .github folder
- the docs folder

See: https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file

However, current rules only support this partially.

Closes #89

## Proposed Changes

Add all paths to all supported files.

## Test Plan

I used these settings locally.
