### PR TITLE
issue#163 is-windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1878,8 +1878,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "find-config": "^1.0.0",
+    "is-windows": "^1.0.2",
     "isbinaryfile": "^4.0.6",
     "jsonfile": "^6.0.1",
     "lodash": "^4.17.15",


### PR DESCRIPTION
Signed-off-by: Matthew B White <whitemat@uk.ibm.com>

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

Hyperledger are using repolinter

## Proposed Changes

Added is-windows as an explicit dependency

## Test Plan

To reproduce and test. 

- clone the repo, and `npm install --production`
- `npm link`
- `repolinter .`

this will fail, as `linguist.js` pulls in `is-windows` but it's not a production dependency.

Repeat the above with the additional dependency and all works as expected