### PR TITLE
Updated the Dockerfile comment to make non git runs work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # To run against the current directory:
 #
-#   docker run -t -v $PWD:/src repolinter
+#   docker run -t -v $PWD:/src -w /src repolinter
 #
 # To run against a remote GitHub repository
 #


### PR DESCRIPTION
## Motivation

I tried running the commands documented in the comments here and found it didn't work.

## Proposed Changes

Just the addition of the -w parmeter on the non-git launch.  Otherwise it tries running in /app and gives results for repolinter.

## Test Plan

n/a
