### PR TITLE
Add contributor-count axiom

### DIFF
--- a/axioms/contributor-count.js
+++ b/axioms/contributor-count.js
@@ -1,0 +1,17 @@
+const gitlog = require('gitlog').default
+
+module.exports = function (fileSystem) {
+  const commits = gitlog({
+    repo: fileSystem.targetDir,
+    all: true,
+    number: 10000 // Fetch the last 10000 commits
+  })
+  if (!commits) {
+    return 0
+  }
+  // Get commit authors and filter unique values
+  const contributors = commits
+    .map((commit) => commit.authorName.toLowerCase())
+    .filter((value, index, self) => self.indexOf(value) === index)
+  return contributors.length
+}

--- a/index.js
+++ b/index.js
@@ -41,6 +41,26 @@ module.exports.lint = function lint (targetDir, filterPaths = [], ruleset = null
       // Execute axiom
       const axiomFunction = require(path.join(__dirname, 'axioms', axiomId))
       targets = targets.concat(axiomName + '=*')
+      // Handle contributor-count axiom
+      if (axiomId === 'contributor-count') {
+        const contributorAxioms = Object.keys(ruleset.rules).filter((rule) =>
+          rule.includes('contributor')
+        )
+        // Evaluate each contributor axiom
+        contributorAxioms.forEach((axiom) => {
+          const operator = axiom.match(/<|>|=/g)[0]
+          const num = Number(axiom.match(/[0-9]+/g)[0])
+          const evaluate = {
+            '<': (a, b) => a < b,
+            '>': (a, b) => a > b,
+            '=': (a, b) => a === b
+          }
+          if (evaluate[operator](axiomFunction(fileSystem), num)) {
+            targets = targets.concat(axiomName + operator + num)
+          }
+        })
+        return
+      }
       targets = targets.concat(axiomFunction(fileSystem).map(axiomOutput => axiomName + '=' + axiomOutput))
     })
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.9.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/core": {
@@ -19,22 +19,22 @@
       "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.8.3",
-        "@babel/generator": "7.9.5",
-        "@babel/helper-module-transforms": "7.9.0",
-        "@babel/helpers": "7.9.2",
-        "@babel/parser": "7.9.4",
-        "@babel/template": "7.8.6",
-        "@babel/traverse": "7.9.5",
-        "@babel/types": "7.9.5",
-        "convert-source-map": "1.7.0",
-        "debug": "4.1.1",
-        "gensync": "1.0.0-beta.1",
-        "json5": "2.1.3",
-        "lodash": "4.17.15",
-        "resolve": "1.15.1",
-        "semver": "5.7.1",
-        "source-map": "0.5.7"
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -43,7 +43,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "lodash": {
@@ -60,10 +60,10 @@
       "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.9.5",
-        "jsesc": "2.5.2",
-        "lodash": "4.17.15",
-        "source-map": "0.5.7"
+        "@babel/types": "^7.9.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "lodash": {
@@ -80,9 +80,9 @@
       "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.8.3",
-        "@babel/template": "7.8.6",
-        "@babel/types": "7.9.5"
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.9.5"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -91,7 +91,7 @@
       "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.9.5"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -100,7 +100,7 @@
       "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.9.5"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-module-imports": {
@@ -109,7 +109,7 @@
       "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.9.5"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-module-transforms": {
@@ -118,13 +118,13 @@
       "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.8.3",
-        "@babel/helper-replace-supers": "7.8.6",
-        "@babel/helper-simple-access": "7.8.3",
-        "@babel/helper-split-export-declaration": "7.8.3",
-        "@babel/template": "7.8.6",
-        "@babel/types": "7.9.5",
-        "lodash": "4.17.15"
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "lodash": {
@@ -141,7 +141,7 @@
       "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.9.5"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-replace-supers": {
@@ -150,10 +150,10 @@
       "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "7.8.3",
-        "@babel/helper-optimise-call-expression": "7.8.3",
-        "@babel/traverse": "7.9.5",
-        "@babel/types": "7.9.5"
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6"
       }
     },
     "@babel/helper-simple-access": {
@@ -162,8 +162,8 @@
       "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.8.6",
-        "@babel/types": "7.9.5"
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -172,7 +172,7 @@
       "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.9.5"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -187,9 +187,9 @@
       "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.8.6",
-        "@babel/traverse": "7.9.5",
-        "@babel/types": "7.9.5"
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0"
       }
     },
     "@babel/highlight": {
@@ -198,9 +198,9 @@
       "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "7.9.5",
-        "chalk": "2.4.2",
-        "js-tokens": "4.0.0"
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
@@ -215,9 +215,9 @@
       "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.8.3",
-        "@babel/parser": "7.9.4",
-        "@babel/types": "7.9.5"
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
       }
     },
     "@babel/traverse": {
@@ -226,15 +226,15 @@
       "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.8.3",
-        "@babel/generator": "7.9.5",
-        "@babel/helper-function-name": "7.9.5",
-        "@babel/helper-split-export-declaration": "7.8.3",
-        "@babel/parser": "7.9.4",
-        "@babel/types": "7.9.5",
-        "debug": "4.1.1",
-        "globals": "11.12.0",
-        "lodash": "4.17.15"
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.5",
+        "@babel/helper-function-name": "^7.9.5",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.9.0",
+        "@babel/types": "^7.9.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
       },
       "dependencies": {
         "debug": {
@@ -243,7 +243,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "lodash": {
@@ -260,9 +260,9 @@
       "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "7.9.5",
-        "lodash": "4.17.15",
-        "to-fast-properties": "2.0.0"
+        "@babel/helper-validator-identifier": "^7.9.5",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -279,10 +279,10 @@
       "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "find-up": "4.1.0",
-        "js-yaml": "3.13.1",
-        "resolve-from": "5.0.0"
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -291,8 +291,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
@@ -301,7 +301,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "p-locate": {
@@ -310,7 +310,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.2.0"
           }
         },
         "path-exists": {
@@ -342,7 +342,7 @@
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.7.2"
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "@sinonjs/formatio": {
@@ -351,8 +351,8 @@
       "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.7.2",
-        "@sinonjs/samsam": "5.0.3"
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
       }
     },
     "@sinonjs/samsam": {
@@ -361,9 +361,9 @@
       "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.7.2",
-        "lodash.get": "4.4.2",
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
       }
     },
     "@sinonjs/text-encoding": {
@@ -396,8 +396,8 @@
       "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
       "dev": true,
       "requires": {
-        "clean-stack": "2.2.0",
-        "indent-string": "4.0.0"
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       }
     },
     "ajv": {
@@ -406,10 +406,10 @@
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "3.1.1",
-        "fast-json-stable-stringify": "2.1.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {
@@ -424,7 +424,7 @@
       "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "requires": {
-        "type-fest": "0.11.0"
+        "type-fest": "^0.11.0"
       },
       "dependencies": {
         "type-fest": {
@@ -446,7 +446,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -455,8 +455,8 @@
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
       "requires": {
-        "normalize-path": "3.0.0",
-        "picomatch": "2.2.2"
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "append-transform": {
@@ -465,7 +465,7 @@
       "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "3.0.0"
+        "default-require-extensions": "^3.0.0"
       }
     },
     "archy": {
@@ -480,7 +480,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-includes": {
@@ -489,9 +489,9 @@
       "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "is-string": "1.0.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0",
+        "is-string": "^1.0.5"
       }
     },
     "assertion-error": {
@@ -522,7 +522,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -532,7 +532,7 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
-        "fill-range": "7.0.1"
+        "fill-range": "^7.0.1"
       }
     },
     "browser-stdout": {
@@ -547,10 +547,10 @@
       "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
       "dev": true,
       "requires": {
-        "hasha": "5.2.0",
-        "make-dir": "3.0.2",
-        "package-hash": "4.0.0",
-        "write-file-atomic": "3.0.3"
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
       }
     },
     "callsites": {
@@ -571,12 +571,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-string": {
@@ -590,9 +590,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -613,14 +613,14 @@
       "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
       "dev": true,
       "requires": {
-        "anymatch": "3.1.1",
-        "braces": "3.0.2",
-        "fsevents": "2.1.2",
-        "glob-parent": "5.1.1",
-        "is-binary-path": "2.1.0",
-        "is-glob": "4.0.1",
-        "normalize-path": "3.0.0",
-        "readdirp": "3.2.0"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
       }
     },
     "clean-stack": {
@@ -635,7 +635,7 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "3.1.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
@@ -650,9 +650,9 @@
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0",
-        "wrap-ansi": "5.1.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -667,9 +667,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -678,7 +678,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -719,7 +719,7 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "cross-spawn": {
@@ -728,9 +728,9 @@
       "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
       "dev": true,
       "requires": {
-        "path-key": "3.1.1",
-        "shebang-command": "2.0.0",
-        "which": "2.0.2"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       },
       "dependencies": {
         "which": {
@@ -739,7 +739,7 @@
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -750,7 +750,7 @@
       "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.1.1"
+        "ms": "^2.1.1"
       }
     },
     "debug-log": {
@@ -771,7 +771,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -786,7 +786,7 @@
       "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
       "dev": true,
       "requires": {
-        "strip-bom": "4.0.0"
+        "strip-bom": "^4.0.0"
       }
     },
     "define-properties": {
@@ -795,7 +795,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "deglob": {
@@ -804,12 +804,12 @@
       "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
       "dev": true,
       "requires": {
-        "find-root": "1.1.0",
-        "glob": "7.1.6",
-        "ignore": "5.1.4",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.9",
-        "uniq": "1.0.1"
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^5.0.0",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
       },
       "dependencies": {
         "ignore": {
@@ -832,7 +832,7 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.3"
+        "esutils": "^2.0.2"
       }
     },
     "emoji-regex": {
@@ -847,7 +847,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -856,17 +856,17 @@
       "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.2.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "has-symbols": "1.0.1",
-        "is-callable": "1.1.5",
-        "is-regex": "1.0.5",
-        "object-inspect": "1.7.0",
-        "object-keys": "1.1.1",
-        "object.assign": "4.1.0",
-        "string.prototype.trimleft": "2.1.2",
-        "string.prototype.trimright": "2.1.2"
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -875,9 +875,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.5",
-        "is-date-object": "1.0.2",
-        "is-symbol": "1.0.3"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-error": {
@@ -897,43 +897,43 @@
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.8.3",
-        "ajv": "6.12.0",
-        "chalk": "2.4.2",
-        "cross-spawn": "6.0.5",
-        "debug": "4.1.1",
-        "doctrine": "3.0.0",
-        "eslint-scope": "5.0.0",
-        "eslint-utils": "1.4.3",
-        "eslint-visitor-keys": "1.1.0",
-        "espree": "6.2.1",
-        "esquery": "1.2.0",
-        "esutils": "2.0.3",
-        "file-entry-cache": "5.0.1",
-        "functional-red-black-tree": "1.0.1",
-        "glob-parent": "5.1.1",
-        "globals": "12.4.0",
-        "ignore": "4.0.6",
-        "import-fresh": "3.2.1",
-        "imurmurhash": "0.1.4",
-        "inquirer": "7.1.0",
-        "is-glob": "4.0.1",
-        "js-yaml": "3.13.1",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.15",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.3",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.3",
-        "progress": "2.0.3",
-        "regexpp": "2.0.1",
-        "semver": "6.3.0",
-        "strip-ansi": "5.2.0",
-        "strip-json-comments": "3.1.0",
-        "table": "5.4.6",
-        "text-table": "0.2.0",
-        "v8-compile-cache": "2.1.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -948,11 +948,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.7.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           },
           "dependencies": {
             "semver": {
@@ -969,7 +969,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "globals": {
@@ -978,7 +978,7 @@
           "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "dev": true,
           "requires": {
-            "type-fest": "0.8.1"
+            "type-fest": "^0.8.1"
           }
         },
         "lodash": {
@@ -1005,7 +1005,7 @@
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -1020,7 +1020,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "strip-json-comments": {
@@ -1049,8 +1049,8 @@
       "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.15.1"
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
       },
       "dependencies": {
         "debug": {
@@ -1076,8 +1076,8 @@
       "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "2.0.0"
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1095,7 +1095,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -1104,8 +1104,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "ms": {
@@ -1120,7 +1120,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -1129,7 +1129,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -1144,7 +1144,7 @@
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0"
+            "find-up": "^2.1.0"
           }
         }
       }
@@ -1155,8 +1155,8 @@
       "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
       "dev": true,
       "requires": {
-        "eslint-utils": "1.4.3",
-        "regexpp": "3.1.0"
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^3.0.0"
       },
       "dependencies": {
         "regexpp": {
@@ -1173,17 +1173,17 @@
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
-        "array-includes": "3.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.3",
-        "eslint-module-utils": "2.6.0",
-        "has": "1.0.3",
-        "minimatch": "3.0.4",
-        "object.values": "1.1.1",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.15.1"
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -1225,12 +1225,12 @@
       "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "2.0.0",
-        "eslint-utils": "1.4.3",
-        "ignore": "5.1.4",
-        "minimatch": "3.0.4",
-        "resolve": "1.15.1",
-        "semver": "6.3.0"
+        "eslint-plugin-es": "^2.0.0",
+        "eslint-utils": "^1.4.2",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
       },
       "dependencies": {
         "ignore": {
@@ -1259,15 +1259,15 @@
       "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
       "dev": true,
       "requires": {
-        "array-includes": "3.1.1",
-        "doctrine": "2.1.0",
-        "has": "1.0.3",
-        "jsx-ast-utils": "2.2.3",
-        "object.entries": "1.1.1",
-        "object.fromentries": "2.0.2",
-        "object.values": "1.1.1",
-        "prop-types": "15.7.2",
-        "resolve": "1.15.1"
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
       },
       "dependencies": {
         "doctrine": {
@@ -1276,7 +1276,7 @@
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
-            "esutils": "2.0.3"
+            "esutils": "^2.0.2"
           }
         }
       }
@@ -1293,8 +1293,8 @@
       "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.3.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -1303,7 +1303,7 @@
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "1.1.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -1318,9 +1318,9 @@
       "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "7.1.1",
-        "acorn-jsx": "5.2.0",
-        "eslint-visitor-keys": "1.1.0"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "esprima": {
@@ -1335,7 +1335,7 @@
       "integrity": "sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==",
       "dev": true,
       "requires": {
-        "estraverse": "5.0.0"
+        "estraverse": "^5.0.0"
       },
       "dependencies": {
         "estraverse": {
@@ -1352,7 +1352,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.3.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1373,9 +1373,9 @@
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -1402,7 +1402,7 @@
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1411,7 +1411,7 @@
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "2.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "fill-range": {
@@ -1420,7 +1420,7 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "to-regex-range": "5.0.1"
+        "to-regex-range": "^5.0.1"
       }
     },
     "find-cache-dir": {
@@ -1429,9 +1429,9 @@
       "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "3.0.2",
-        "pkg-dir": "4.2.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
       }
     },
     "find-config": {
@@ -1439,7 +1439,7 @@
       "resolved": "https://registry.npmjs.org/find-config/-/find-config-1.0.0.tgz",
       "integrity": "sha1-6vorm8B/qckOmgw++c7PHMgA9TA=",
       "requires": {
-        "user-home": "2.0.0"
+        "user-home": "^2.0.0"
       }
     },
     "find-root": {
@@ -1454,7 +1454,7 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "locate-path": "3.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "flat": {
@@ -1463,7 +1463,7 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "dev": true,
       "requires": {
-        "is-buffer": "2.0.4"
+        "is-buffer": "~2.0.3"
       }
     },
     "flat-cache": {
@@ -1472,7 +1472,7 @@
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "flatted": "2.0.2",
+        "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
       },
@@ -1483,7 +1483,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.6"
+            "glob": "^7.1.3"
           }
         }
       }
@@ -1500,8 +1500,8 @@
       "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "7.0.2",
-        "signal-exit": "3.0.3"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "fromentries": {
@@ -1558,17 +1558,36 @@
       "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
       "dev": true
     },
+    "gitlog": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gitlog/-/gitlog-4.0.0.tgz",
+      "integrity": "sha512-N6ZcvvbHsqhmM09wtzbL8v3FPwBK3EQ1xnv/2nj9JGH/YsYVn+ZkmMCxzkEjHnSFcpUk2HN2LBp76PGj3TkPag==",
+      "requires": {
+        "debug": "^4.1.1",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.4",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -1577,7 +1596,7 @@
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
-        "is-glob": "4.0.1"
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -1603,7 +1622,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -1623,8 +1642,8 @@
       "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
       "dev": true,
       "requires": {
-        "is-stream": "2.0.0",
-        "type-fest": "0.8.1"
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
       }
     },
     "he": {
@@ -1651,7 +1670,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -1666,8 +1685,8 @@
       "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "dev": true,
       "requires": {
-        "parent-module": "1.0.1",
-        "resolve-from": "4.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -1695,8 +1714,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1710,19 +1729,19 @@
       "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "4.3.1",
-        "chalk": "3.0.0",
-        "cli-cursor": "3.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.1.0",
-        "figures": "3.2.0",
-        "lodash": "4.17.15",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "2.4.0",
-        "rxjs": "6.5.5",
-        "string-width": "4.2.0",
-        "strip-ansi": "6.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1737,8 +1756,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "chalk": {
@@ -1747,8 +1766,8 @@
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
-            "ansi-styles": "4.2.1",
-            "supports-color": "7.1.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
         "color-convert": {
@@ -1757,7 +1776,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -1796,9 +1815,9 @@
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "8.0.0",
-            "is-fullwidth-code-point": "3.0.0",
-            "strip-ansi": "6.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
@@ -1807,7 +1826,7 @@
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.0"
+            "ansi-regex": "^5.0.0"
           }
         },
         "supports-color": {
@@ -1816,7 +1835,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -1833,7 +1852,7 @@
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "requires": {
-        "binary-extensions": "2.0.0"
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-buffer": {
@@ -1872,7 +1891,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-number": {
@@ -1893,7 +1912,7 @@
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.3"
       }
     },
     "is-stream": {
@@ -1914,7 +1933,7 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -1957,7 +1976,7 @@
       "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
       "dev": true,
       "requires": {
-        "append-transform": "2.0.0"
+        "append-transform": "^2.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -1966,13 +1985,13 @@
       "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.9.0",
-        "@babel/parser": "7.9.4",
-        "@babel/template": "7.8.6",
-        "@babel/traverse": "7.9.5",
-        "@istanbuljs/schema": "0.1.2",
-        "istanbul-lib-coverage": "3.0.0",
-        "semver": "6.3.0"
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -1989,13 +2008,13 @@
       "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "cross-spawn": "7.0.2",
-        "istanbul-lib-coverage": "3.0.0",
-        "make-dir": "3.0.2",
-        "p-map": "3.0.0",
-        "rimraf": "3.0.2",
-        "uuid": "3.4.0"
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
       },
       "dependencies": {
         "uuid": {
@@ -2012,9 +2031,9 @@
       "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "3.0.0",
-        "make-dir": "3.0.2",
-        "supports-color": "7.1.0"
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
         "has-flag": {
@@ -2029,7 +2048,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -2040,9 +2059,9 @@
       "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "istanbul-lib-coverage": "3.0.0",
-        "source-map": "0.6.1"
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "debug": {
@@ -2051,7 +2070,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "source-map": {
@@ -2068,8 +2087,8 @@
       "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
       "dev": true,
       "requires": {
-        "html-escaper": "2.0.2",
-        "istanbul-lib-report": "3.0.0"
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
       }
     },
     "js-tokens": {
@@ -2084,8 +2103,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsesc": {
@@ -2118,7 +2137,7 @@
       "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "^1.2.5"
       }
     },
     "jsonfile": {
@@ -2126,8 +2145,8 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
       "requires": {
-        "graceful-fs": "4.2.3",
-        "universalify": "1.0.0"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
       }
     },
     "jsx-ast-utils": {
@@ -2136,8 +2155,8 @@
       "integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
       "dev": true,
       "requires": {
-        "array-includes": "3.1.1",
-        "object.assign": "4.1.0"
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
       }
     },
     "just-extend": {
@@ -2152,8 +2171,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -2162,10 +2181,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.3",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -2182,8 +2201,8 @@
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "3.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -2208,7 +2227,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.4.2"
       }
     },
     "loose-envify": {
@@ -2217,7 +2236,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "make-dir": {
@@ -2226,7 +2245,7 @@
       "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
       "dev": true,
       "requires": {
-        "semver": "6.3.0"
+        "semver": "^6.0.0"
       },
       "dependencies": {
         "semver": {
@@ -2242,8 +2261,8 @@
       "resolved": "https://registry.npmjs.org/matched/-/matched-5.0.0.tgz",
       "integrity": "sha512-O0LCuxYYBNBjP2dmAg0i6PME0Mb0dvjulpMC0tTIeMRh6kXYsugOT5GOWpFkSzqjQjgOUs/eiyvpVhXdN2La4g==",
       "requires": {
-        "glob": "7.1.6",
-        "picomatch": "2.2.2"
+        "glob": "^7.1.6",
+        "picomatch": "^2.2.1"
       }
     },
     "mimic-fn": {
@@ -2257,7 +2276,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2272,7 +2291,7 @@
       "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -2313,12 +2332,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "supports-color": {
@@ -2327,7 +2346,7 @@
           "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -2335,8 +2354,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -2362,11 +2380,11 @@
       "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.7.2",
-        "@sinonjs/fake-timers": "6.0.1",
-        "@sinonjs/text-encoding": "0.7.1",
-        "just-extend": "4.1.0",
-        "path-to-regexp": "1.8.0"
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
       }
     },
     "node-environment-flags": {
@@ -2375,8 +2393,8 @@
       "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "2.1.0",
-        "semver": "5.7.1"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       }
     },
     "node-preload": {
@@ -2385,7 +2403,7 @@
       "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
       "dev": true,
       "requires": {
-        "process-on-spawn": "1.0.0"
+        "process-on-spawn": "^1.0.0"
       }
     },
     "normalize-package-data": {
@@ -2394,10 +2412,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.8.8",
-        "resolve": "1.15.1",
-        "semver": "5.7.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -2412,32 +2430,32 @@
       "integrity": "sha512-n0MBXYBYRqa67IVt62qW1r/d9UH/Qtr7SF1w/nQLJ9KxvWF6b2xCHImRAixHN9tnMMYHC2P14uo6KddNGwMgGg==",
       "dev": true,
       "requires": {
-        "@istanbuljs/load-nyc-config": "1.0.0",
-        "@istanbuljs/schema": "0.1.2",
-        "caching-transform": "4.0.0",
-        "convert-source-map": "1.7.0",
-        "decamelize": "1.2.0",
-        "find-cache-dir": "3.3.1",
-        "find-up": "4.1.0",
-        "foreground-child": "2.0.0",
-        "glob": "7.1.6",
-        "istanbul-lib-coverage": "3.0.0",
-        "istanbul-lib-hook": "3.0.0",
-        "istanbul-lib-instrument": "4.0.1",
-        "istanbul-lib-processinfo": "2.0.2",
-        "istanbul-lib-report": "3.0.0",
-        "istanbul-lib-source-maps": "4.0.0",
-        "istanbul-reports": "3.0.2",
-        "make-dir": "3.0.2",
-        "node-preload": "0.2.1",
-        "p-map": "3.0.0",
-        "process-on-spawn": "1.0.0",
-        "resolve-from": "5.0.0",
-        "rimraf": "3.0.2",
-        "signal-exit": "3.0.3",
-        "spawn-wrap": "2.0.0",
-        "test-exclude": "6.0.0",
-        "yargs": "15.3.1"
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2452,8 +2470,8 @@
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "@types/color-name": "1.1.1",
-            "color-convert": "2.0.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "cliui": {
@@ -2462,9 +2480,9 @@
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "dev": true,
           "requires": {
-            "string-width": "4.2.0",
-            "strip-ansi": "6.0.0",
-            "wrap-ansi": "6.2.0"
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
           }
         },
         "color-convert": {
@@ -2473,7 +2491,7 @@
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.4"
+            "color-name": "~1.1.4"
           }
         },
         "color-name": {
@@ -2494,8 +2512,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -2510,7 +2528,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "p-locate": {
@@ -2519,7 +2537,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.2.0"
           }
         },
         "path-exists": {
@@ -2534,9 +2552,9 @@
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "8.0.0",
-            "is-fullwidth-code-point": "3.0.0",
-            "strip-ansi": "6.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
@@ -2545,7 +2563,7 @@
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.0"
+            "ansi-regex": "^5.0.0"
           }
         },
         "wrap-ansi": {
@@ -2554,9 +2572,9 @@
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "4.2.1",
-            "string-width": "4.2.0",
-            "strip-ansi": "6.0.0"
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "yargs": {
@@ -2565,17 +2583,17 @@
           "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
           "dev": true,
           "requires": {
-            "cliui": "6.0.0",
-            "decamelize": "1.2.0",
-            "find-up": "4.1.0",
-            "get-caller-file": "2.0.5",
-            "require-directory": "2.1.1",
-            "require-main-filename": "2.0.0",
-            "set-blocking": "2.0.0",
-            "string-width": "4.2.0",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "18.1.2"
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
           }
         },
         "yargs-parser": {
@@ -2584,8 +2602,8 @@
           "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -2614,10 +2632,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.1",
-        "object-keys": "1.1.1"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.entries": {
@@ -2626,10 +2644,10 @@
       "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "object.fromentries": {
@@ -2638,10 +2656,10 @@
       "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
@@ -2650,8 +2668,8 @@
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.values": {
@@ -2660,10 +2678,10 @@
       "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {
@@ -2671,7 +2689,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -2680,7 +2698,7 @@
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "2.1.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optionator": {
@@ -2689,12 +2707,12 @@
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "word-wrap": "1.2.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "os-homedir": {
@@ -2714,7 +2732,7 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
-        "p-try": "2.2.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
@@ -2723,7 +2741,7 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "2.3.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-map": {
@@ -2732,7 +2750,7 @@
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "dev": true,
       "requires": {
-        "aggregate-error": "3.0.1"
+        "aggregate-error": "^3.0.0"
       }
     },
     "p-try": {
@@ -2747,10 +2765,10 @@
       "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.2.3",
-        "hasha": "5.2.0",
-        "lodash.flattendeep": "4.4.0",
-        "release-zalgo": "1.0.0"
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
       }
     },
     "parent-module": {
@@ -2759,7 +2777,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "requires": {
-        "callsites": "3.1.0"
+        "callsites": "^3.0.0"
       }
     },
     "parse-json": {
@@ -2768,7 +2786,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -2809,7 +2827,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pathval": {
@@ -2835,8 +2853,8 @@
       "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
-        "find-up": "3.0.0",
-        "load-json-file": "5.3.0"
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
       },
       "dependencies": {
         "load-json-file": {
@@ -2845,11 +2863,11 @@
           "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.2.3",
-            "parse-json": "4.0.0",
-            "pify": "4.0.1",
-            "strip-bom": "3.0.0",
-            "type-fest": "0.3.1"
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
           }
         },
         "parse-json": {
@@ -2858,8 +2876,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "pify": {
@@ -2888,9 +2906,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.1.0",
-        "xtend": "4.0.2"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkg-dir": {
@@ -2899,7 +2917,7 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "requires": {
-        "find-up": "4.1.0"
+        "find-up": "^4.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -2908,8 +2926,8 @@
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "locate-path": "5.0.0",
-            "path-exists": "4.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
@@ -2918,7 +2936,7 @@
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "dev": true,
           "requires": {
-            "p-locate": "4.1.0"
+            "p-locate": "^4.1.0"
           }
         },
         "p-locate": {
@@ -2927,7 +2945,7 @@
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
           "dev": true,
           "requires": {
-            "p-limit": "2.3.0"
+            "p-limit": "^2.2.0"
           }
         },
         "path-exists": {
@@ -2950,7 +2968,7 @@
       "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
       "dev": true,
       "requires": {
-        "fromentries": "1.2.0"
+        "fromentries": "^1.2.0"
       }
     },
     "progress": {
@@ -2965,9 +2983,9 @@
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "react-is": "16.13.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "punycode": {
@@ -2988,9 +3006,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.5.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -2999,8 +3017,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -3009,7 +3027,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "locate-path": {
@@ -3018,8 +3036,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -3028,7 +3046,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -3037,7 +3055,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.3.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -3054,7 +3072,7 @@
       "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
       "dev": true,
       "requires": {
-        "picomatch": "2.2.2"
+        "picomatch": "^2.0.4"
       }
     },
     "regexpp": {
@@ -3069,7 +3087,7 @@
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
-        "es6-error": "4.1.1"
+        "es6-error": "^4.0.1"
       }
     },
     "require-directory": {
@@ -3090,7 +3108,7 @@
       "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -3105,8 +3123,8 @@
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "5.1.0",
-        "signal-exit": "3.0.3"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -3114,7 +3132,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
-        "glob": "7.1.6"
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
@@ -3123,7 +3141,7 @@
       "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-parallel": {
@@ -3138,7 +3156,7 @@
       "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dev": true,
       "requires": {
-        "tslib": "1.11.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -3171,7 +3189,7 @@
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "shebang-regex": "3.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
@@ -3191,7 +3209,7 @@
       "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
       "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
       "requires": {
-        "debug": "4.1.1"
+        "debug": "^4.0.1"
       },
       "dependencies": {
         "debug": {
@@ -3199,7 +3217,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -3215,13 +3233,13 @@
       "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.7.2",
-        "@sinonjs/fake-timers": "6.0.1",
-        "@sinonjs/formatio": "5.0.1",
-        "@sinonjs/samsam": "5.0.3",
-        "diff": "4.0.2",
-        "nise": "4.0.3",
-        "supports-color": "7.1.0"
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
         "diff": {
@@ -3242,7 +3260,7 @@
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "4.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -3253,9 +3271,9 @@
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "astral-regex": "1.0.0",
-        "is-fullwidth-code-point": "2.0.0"
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "source-map": {
@@ -3270,12 +3288,12 @@
       "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
       "dev": true,
       "requires": {
-        "foreground-child": "2.0.0",
-        "is-windows": "1.0.2",
-        "make-dir": "3.0.2",
-        "rimraf": "3.0.2",
-        "signal-exit": "3.0.3",
-        "which": "2.0.2"
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
       },
       "dependencies": {
         "which": {
@@ -3284,7 +3302,7 @@
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -3295,8 +3313,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -3311,8 +3329,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.5"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -3333,15 +3351,15 @@
       "integrity": "sha512-HBEAD5eVXrr2o/KZ3kU8Wwaxw90wzoq4dOQe6vlRnPoQ6stn4LCLRLBBDp0CjH/aOTL9bDZJbRUOZcBaBnNJ0A==",
       "dev": true,
       "requires": {
-        "eslint": "6.8.0",
+        "eslint": "~6.8.0",
         "eslint-config-standard": "14.1.0",
         "eslint-config-standard-jsx": "8.1.0",
-        "eslint-plugin-import": "2.18.2",
-        "eslint-plugin-node": "10.0.0",
-        "eslint-plugin-promise": "4.2.1",
-        "eslint-plugin-react": "7.14.3",
-        "eslint-plugin-standard": "4.0.1",
-        "standard-engine": "12.0.0"
+        "eslint-plugin-import": "~2.18.0",
+        "eslint-plugin-node": "~10.0.0",
+        "eslint-plugin-promise": "~4.2.1",
+        "eslint-plugin-react": "~7.14.2",
+        "eslint-plugin-standard": "~4.0.0",
+        "standard-engine": "^12.0.0"
       }
     },
     "standard-engine": {
@@ -3350,10 +3368,10 @@
       "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
       "dev": true,
       "requires": {
-        "deglob": "4.0.1",
-        "get-stdin": "7.0.0",
-        "minimist": "1.2.5",
-        "pkg-conf": "3.1.0"
+        "deglob": "^4.0.0",
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^3.1.0"
       }
     },
     "standardjs": {
@@ -3367,8 +3385,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string.prototype.trimend": {
@@ -3377,8 +3395,8 @@
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string.prototype.trimleft": {
@@ -3387,9 +3405,9 @@
       "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "string.prototype.trimstart": "1.0.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
       }
     },
     "string.prototype.trimright": {
@@ -3398,9 +3416,9 @@
       "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5",
-        "string.prototype.trimend": "1.0.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {
@@ -3409,8 +3427,8 @@
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.5"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "strip-ansi": {
@@ -3419,7 +3437,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -3439,7 +3457,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "table": {
@@ -3448,10 +3466,10 @@
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "6.12.0",
-        "lodash": "4.17.15",
-        "slice-ansi": "2.1.0",
-        "string-width": "3.1.0"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3472,9 +3490,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -3483,7 +3501,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -3494,9 +3512,9 @@
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "dev": true,
       "requires": {
-        "@istanbuljs/schema": "0.1.2",
-        "glob": "7.1.6",
-        "minimatch": "3.0.4"
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
       }
     },
     "text-table": {
@@ -3517,7 +3535,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -3532,14 +3550,13 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
-        "is-number": "7.0.0"
+        "is-number": "^7.0.0"
       }
     },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -3547,7 +3564,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -3568,7 +3585,7 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "uniq": {
@@ -3588,7 +3605,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "user-home": {
@@ -3596,7 +3613,7 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "uuid": {
@@ -3616,8 +3633,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "which": {
@@ -3626,7 +3643,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -3641,7 +3658,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "word-wrap": {
@@ -3656,9 +3673,9 @@
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3673,9 +3690,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -3684,7 +3701,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -3700,7 +3717,7 @@
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.3"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -3709,10 +3726,10 @@
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4",
-        "is-typedarray": "1.0.0",
-        "signal-exit": "3.0.3",
-        "typedarray-to-buffer": "3.1.5"
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "xtend": {
@@ -3733,16 +3750,16 @@
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dev": true,
       "requires": {
-        "cliui": "5.0.0",
-        "find-up": "3.0.0",
-        "get-caller-file": "2.0.5",
-        "require-directory": "2.1.1",
-        "require-main-filename": "2.0.0",
-        "set-blocking": "2.0.0",
-        "string-width": "3.1.0",
-        "which-module": "2.0.0",
-        "y18n": "4.0.0",
-        "yargs-parser": "13.1.2"
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3757,9 +3774,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "7.0.3",
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "5.2.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
@@ -3768,7 +3785,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -3779,8 +3796,8 @@
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
-        "camelcase": "5.3.1",
-        "decamelize": "1.2.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     },
     "yargs-unparser": {
@@ -3789,9 +3806,9 @@
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "dev": true,
       "requires": {
-        "flat": "4.1.0",
-        "lodash": "4.17.15",
-        "yargs": "13.3.2"
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "lodash": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "find-config": "^1.0.0",
+    "gitlog": "^4.0.0",
     "is-windows": "^1.0.2",
     "isbinaryfile": "^4.0.6",
     "jsonfile": "^6.0.1",

--- a/tests/axioms/contributor_count_test.js
+++ b/tests/axioms/contributor_count_test.js
@@ -1,0 +1,22 @@
+const chai = require('chai')
+const expect = chai.expect
+const path = require('path')
+const FileSystem = require('../../lib/file_system')
+const contributors = require('../../axioms/contributor-count')
+const repolinter = require(path.resolve('.'))
+
+describe('contributors axiom', () => {
+  it('repolinter contributor count greater than zero', () => {
+    const fs = new FileSystem(path.resolve('.'))
+    const contributorCount = contributors(fs)
+    expect(contributorCount).to.satisfy((count) => count > 0)
+  })
+
+  it('rule enabled because contributor count greater than ten', () => {
+    const result = repolinter.lint(path.resolve('tests/package'))
+    const { rule } = result
+      .map((r) => r[0])
+      .find((res) => res.rule.id === 'contributing-file-exists')
+    expect(rule.enabled).to.equal(true)
+  })
+})

--- a/tests/package/repolinter.json
+++ b/tests/package/repolinter.json
@@ -1,8 +1,14 @@
 {
+  "axioms": {
+    "contributor-count": "contributor-count"
+  },
   "rules": {
     "all": {
       "readme-file-exists:file-existence": ["error", {"files": ["README*"]}],
       "test-exists:file-existence": ["error", {"files": ["repolinter_tests.js"]}]
+    },
+    "contributor-count>10": {
+      "contributing-file-exists:file-existence": ["info", {"files": ["CONTRIB*"]}]
     }
   }
 }


### PR DESCRIPTION
## Motivation

See issue #169 

## Proposed Changes

Adds axiom to enable rules only on projects with a certain amount of contributors. Uses the [node-gitlog](https://github.com/domharrington/node-gitlog) library to get the contributor count of the repository by looking at the commit authors. This result can be a bit higher than the actual contributor count in some cases, as some authors could be bots or use different names in their commits but it seems to be quite accurate.

The axiom can be included and used like any other axiom, but it also supports the greater than or lesser than symbols. See [tests/package/repolint.json](https://github.com/nokia/repolinter/blob/a890f8ab11c86daa2d303a04c97af888dd8a1498/tests/package/repolinter.json#L10) for an example. 

## Test Plan

Some tests are included in `tests/axioms/contributor_count_test.js`.
