### PR TITLE
Add settings.yml to list maintainers

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -18,3 +18,6 @@ repository:
 collaborators:
   - username: caniszczyk
     permission: admin
+    
+  - username: trevmex
+    permission: admin

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,20 @@
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+
+  # The name of the repository. Changing this will rename the repository
+  name: repolinter
+
+  # A short description of the repository that will show up on GitHub
+  description: Repolinter: Open Source Repository Linter
+
+  # A URL with more information about the repository
+  homepage: https://todogroup.org
+  
+  # Collaborators: give specific users access to this repository.
+  # see /governance/roles.md for details on write access policy
+  # note that the permissions below may provide wider access than needed for
+  # a specific role, and we trust these individuals to act according to their
+  # role. If there are questions, please contact one of the chairs.
+collaborators:
+  - username: caniszczyk
+    permission: admin


### PR DESCRIPTION
Add a simple settings.yml to track settings and maintainer access.

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>

