### PR TITLE
Add  "dirs": true to check for multiple pull request and issue templates

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -167,7 +167,7 @@
             "rule": {
                 "type": "file-existence",
                 "options": {
-                    "globsAny": ["ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE/*"]
+                    "globsAny": ["ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE*"]
                 }
             }
         },

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -163,15 +163,17 @@
         },
         "github-issue-template-exists": {
             "level": "error",
+            "dirs": true,
             "rule": {
                 "type": "file-existence",
                 "options": {
-                    "globsAny": ["ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE*"]
+                    "globsAny": ["ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE/*"]
                 }
             }
         },
         "github-pull-request-template-exists": {
             "level": "error",
+            "dirs": true,
             "rule": {
                 "type": "file-existence",
                 "options": {

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -163,20 +163,20 @@
         },
         "github-issue-template-exists": {
             "level": "error",
-            "dirs": true,
             "rule": {
                 "type": "file-existence",
                 "options": {
+                    "dirs": true,
                     "globsAny": ["ISSUE_TEMPLATE*", ".github/ISSUE_TEMPLATE*"]
                 }
             }
         },
         "github-pull-request-template-exists": {
             "level": "error",
-            "dirs": true,
             "rule": {
                 "type": "file-existence",
                 "options": {
+                    "dirs": true,
                     "globsAny": ["PULL_REQUEST_TEMPLATE*", ".github/PULL_REQUEST_TEMPLATE*"]
                 }
             }


### PR DESCRIPTION
Signed-off-by: John Mertic <jmertic@linuxfoundation.org>

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

GitHub will create a ISSUE_TEMPLATE or PULL_REQUEST_TEMPLATE folder if the project has multiple templates

## Proposed Changes

Add ` "dirs": true` to the `github-issue-template-exists` and `github-pull-request-template-exists` to check for that folder

## Test Plan

Ran against my project at https://github.com/lf-energy/tsc-template/actions?query=workflow%3A%22Weekly+Lint+repository%22
