### PR TITLE
fix: file-hash now accepts legacy configuration format

### DIFF
--- a/rules/file-hash.js
+++ b/rules/file-hash.js
@@ -15,7 +15,7 @@ const FileSystem = require('../lib/file_system')
  */
 async function fileHash (fs, options) {
   const fileList = options.globsAny || options.files
-  const file = await fs.findFirstFile(options.globsAny, options.nocase)
+  const file = await fs.findFirstFile(fileList, options.nocase)
 
   if (file === undefined) {
     return new Result(

--- a/tests/rules/file_hash_tests.js
+++ b/tests/rules/file_hash_tests.js
@@ -145,5 +145,28 @@ describe('rule', () => {
 
       expect(actual.passed).to.equal(true)
     })
+
+    it('respect the legacy configuration format', async () => {
+      /** @type {any} */
+      const mockfs = {
+        findFirstFile () {
+          return 'README.md'
+        },
+        getFileContents () {
+          return 'foo'
+        },
+        targetDir: '.'
+      }
+
+      const ruleopts = {
+        files: ['README.md'],
+        hash: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae'
+      }
+
+      const actual = await fileContents(mockfs, ruleopts)
+      expect(actual.passed).to.equal(true)
+      expect(actual.targets).to.have.length(1)
+      expect(actual.targets[0]).to.deep.include({ passed: true, path: 'README.md' })
+    })
   })
 })


### PR DESCRIPTION
This PR fixes a typo preventing the `fileHash` rule from being configured using the legacy format (`files` instead of `globsAny`).

