### PR TITLE
add github action to publish docker images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,36 @@
+name: Publish Docker Image
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+
+jobs:
+  publish_to_ghcr:
+    name: Push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@55d3462 #v1.9.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build and Push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
This adds a GitHub Actions workflow to build and publish docker images for repolinter to [GitHub Container Registry](https://github.blog/2020-09-01-introducing-github-container-registry/).

Container Registry is different from older GitHub Packages in that it allows for anonymous fetching of images, which we'd want for people to be able to simply run:

```
docker run ghcr.io/todogroup/repolinter
```

The downside of Container Registry (for now) is that it requires a Personal Access Token to publish images.  So before merging this change, we would need to add a PAT as a Repository secret on this repo (named `GHCR_PAT`).  The question then is, "a PAT for which user?"  Since the PAT isn't just scoped to this specific repo, it shouldn't be any individual person's account.  We'd probably need to create a dedicated GitHub account ("todogroup-packages" or something), which of course then comes with having to maintain credentials for that account, etc, etc.  Ugh!

[The docs](https://docs.github.com/en/free-pro-team@latest/packages/guides/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry) seem to indicate that this will eventually (hopefully?) change:

> If you want to authenticate to GitHub Container Registry in a GitHub Actions workflow, then you must use a personal access token (PAT). The GITHUB_TOKEN does not currently have the required permissions. During the GitHub Container Registry beta, the only supported form of authentication is the PAT.

But the good news is that if we **do** go through all of that, it works pretty well as you can see [here in the Twitter Forks org](https://github.com/orgs/twitter-forks/packages/container/package/repolinter).  You can test that by running:

```
docker run ghcr.io/twitter-forks/repolinter
```

Once we set all this up, we'd also be able to then publish a pre-built image of the newrelic/repolinter-action image, which allows running repolinter in a GitHub Action **much** faster than using newrelic/repolinter-action today.