### PR TITLE
ci: switch to semantic-release and add docker publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,7 +167,7 @@ jobs:
           NEW_RELEASE_PATCH_VERSION: ${{ steps.semantic.outputs.new_release_patch_version }}
         run: |
           import os
-          major, minor, patch, repo = os.environ["RELEASE_GENERATED"], os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"], os.environ["GITHUB_REPOSITORY"]
+          major, minor, patch, repo = os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"], os.environ["GITHUB_REPOSITORY"]
           tags = f"ghcr.io/{repo}:latest,ghcr.io/{repo}:{major}.{minor},ghcr.io/{repo}:{major}.{minor}.{patch}"
           print(f"::set-output name=tags::{tags}")
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,14 +162,13 @@ jobs:
         id: tags
         shell: python
         env:
-          RELEASE_GENERATED: ${{ steps.semantic.outputs.new_release_published }}
           NEW_RELEASE_MAJOR_VERSION: ${{ steps.semantic.outputs.new_release_major_version }}
           NEW_RELEASE_MINOR_VERSION: ${{ steps.semantic.outputs.new_release_minor_version }}
           NEW_RELEASE_PATCH_VERSION: ${{ steps.semantic.outputs.new_release_patch_version }}
         run: |
           import os
-          published, major, minor, patch = os.environ["RELEASE_GENERATED"], os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"]
-          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}"
+          major, minor, patch, repo = os.environ["RELEASE_GENERATED"], os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"], os.environ["GITHUB_REPOSITORY"]
+          tags = f"ghcr.io/{repo}:latest,ghcr.io/{repo}:{major}.{minor},ghcr.io/{repo}:{major}.{minor}.{patch}"
           print(f"::set-output name=tags::{tags}")
 
       - name: Gather Docker Labels

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Docker Build
         uses: docker/build-push-action@v2
         with:
-          tag: todogroup/repolinter:latest
+          tags: todogroup/repolinter:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,16 +21,18 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Get NPM Cache Directory
+        id: npm-cache
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+
       - name: Cache NPM
-        id: cache-node-modules
         uses: actions/cache@v2
-        env:
-          cache-name: node-modules
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
 
       - name: Install NPM Dependencies
         run: npm ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: todogroup/repolinter:latest
+          load: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,7 @@ jobs:
             @semantic-release/changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache Docker layers
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,6 +132,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v2
         with:
           extra_plugins: |
+            @semantic-release/git
             @semantic-release/changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -158,20 +159,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: Generate Docker Tags
-        if: steps.semantic.outputs.new_release_published == 'true'
-        id: tags
-        shell: python
-        env:
-          NEW_RELEASE_MAJOR_VERSION: ${{ steps.semantic.outputs.new_release_major_version }}
-          NEW_RELEASE_MINOR_VERSION: ${{ steps.semantic.outputs.new_release_minor_version }}
-          NEW_RELEASE_PATCH_VERSION: ${{ steps.semantic.outputs.new_release_patch_version }}
-        run: |
-          import os
-          major, minor, patch, repo = os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"], os.environ["GITHUB_REPOSITORY"]
-          tags = f"ghcr.io/{repo}:latest,ghcr.io/{repo}:{major}.{minor},ghcr.io/{repo}:{major}.{minor}.{patch}"
-          print(f"::set-output name=tags::{tags}")
-
       - name: Gather Docker Labels
         if: steps.semantic.outputs.new_release_published == 'true'
         id: docker_meta
@@ -185,7 +172,10 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: >-
+            ghcr.io/${{ github.repository }}:latest,
+            ghcr.io/${{ github.repository }}:v${{ steps.semantic.outputs.new_release_major_version }}.${{ steps.semantic.outputs.new_release_minor_version }},
+            ghcr.io/${{ github.repository }}:v${{ steps.semantic.outputs.new_release_major_version }}.${{ steps.semantic.outputs.new_release_minor_version }}.${{ steps.semantic.outputs.new_release_patch_version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,6 +137,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Docker layers
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
@@ -145,9 +146,11 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Set up Docker Buildx
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/setup-buildx-action@v1
 
       - name: Login to GitHub Container Registry
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -155,6 +158,7 @@ jobs:
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Generate Docker Tags
+        if: steps.semantic.outputs.new_release_published == 'true'
         id: tags
         shell: python
         env:
@@ -165,16 +169,18 @@ jobs:
         run: |
           import os
           published, major, minor, patch = os.environ["RELEASE_GENERATED"], os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"]
-          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}" if published and published != "false" else "latest"
+          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}"
           print(f"::set-output name=tags::{tags}")
 
       - name: Gather Docker Labels
+        if: steps.semantic.outputs.new_release_published == 'true'
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@55d3462 #v1.9.1
         with:
           images: ghcr.io/${{ github.repository }}
 
       - name: Build and Push to GitHub Container Registry
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 on: [push, pull_request]
 
 jobs:
@@ -86,3 +86,66 @@ jobs:
       - name: Run Test (Windows)
         if: ${{ runner.os == 'Windows' }}
         run: npm test
+
+  test-docker:
+    runs-on: ubuntu-latest
+    name: Docker sample
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          tag: todogroup/repolinter:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Docker Run
+        run: docker run -t -v ${{ github.workspace }}:/src -w /src todogroup/repolinter:latest .
+
+  publish-to-ghcr:
+    name: Push Docker image to GitHub Container Registry
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [test, test-docker]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Gather Docker Metadata
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@55d3462 #v1.9.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build and Push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
         run: docker run -t -v ${{ github.workspace }}:/src -w /src todogroup/repolinter:latest .
 
   publish-release:
-    name: Push Docker image to GitHub Container Registry
+    name: Publish a Release
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     needs: [test, test-docker]
     runs-on: ubuntu-latest
@@ -133,6 +133,14 @@ jobs:
             @semantic-release/changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -155,7 +163,7 @@ jobs:
         run: |
           import os
           published, major, minor, patch = os.environ["RELEASE_GENERATED"], os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"]
-          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}" if not published or published == "false" else "latest"
+          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}" if published and published != "false" else "latest"
           print(f"::set-output name=tags::{tags}")
 
       - name: Gather Docker Labels

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,15 +147,15 @@ jobs:
       - name: Generate Docker Tags
         id: tags
         shell: python
-        with:
-          release_generated: ${{ steps.semantic.outputs.new_release_published }}
-          new_release_major_version: ${{ steps.semantic.outputs.new_release_major_version }}
-          new_release_minor_version: ${{ steps.semantic.outputs.new_release_minor_version }}
-          new_release_patch_version: ${{ steps.semantic.outputs.new_release_patch_version }}
+        env:
+          RELEASE_GENERATED: ${{ steps.semantic.outputs.new_release_published }}
+          NEW_RELEASE_MAJOR_VERSION: ${{ steps.semantic.outputs.new_release_major_version }}
+          NEW_RELEASE_MINOR_VERSION: ${{ steps.semantic.outputs.new_release_minor_version }}
+          NEW_RELEASE_PATCH_VERSION: ${{ steps.semantic.outputs.new_release_patch_version }}
         run: |
           import os
-          published, major, minor, patch = os.environ["INPUT_RELEASE_GENERATED"], os.environ["INPUT_NEW_RELEASE_MAJOR_VERSION"], os.environ["INPUT_NEW_RELEASE_MINOR_VERSION"], os.environ["INPUT_NEW_RELEASE_PATCH_VERSION"]
-          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}" if published else "latest"
+          published, major, minor, patch = os.environ["RELEASE_GENERATED"], os.environ["NEW_RELEASE_MAJOR_VERSION"], os.environ["NEW_RELEASE_MINOR_VERSION"], os.environ["NEW_RELEASE_PATCH_VERSION"]
+          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}" if not published or published == "false" else "latest"
           print(f"::set-output name=tags::{tags}")
 
       - name: Gather Docker Labels

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,20 +116,23 @@ jobs:
       - name: Docker Run
         run: docker run -t -v ${{ github.workspace }}:/src -w /src todogroup/repolinter:latest .
 
-  publish-to-ghcr:
+  publish-release:
     name: Push Docker image to GitHub Container Registry
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     needs: [test, test-docker]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Gather Docker Metadata
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@55d3462 #v1.9.1
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v2
         with:
-          images: ghcr.io/${{ github.repository }}
+          extra_plugins: |
+            @semantic-release/changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -141,12 +144,32 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
 
+      - name: Generate Docker Tags
+        id: tags
+        shell: python
+        with:
+          release_generated: ${{ steps.semantic.outputs.new_release_published }}
+          new_release_major_version: ${{ steps.semantic.outputs.new_release_major_version }}
+          new_release_minor_version: ${{ steps.semantic.outputs.new_release_minor_version }}
+          new_release_patch_version: ${{ steps.semantic.outputs.new_release_patch_version }}
+        run: |
+          import os
+          published, major, minor, patch = os.environ["INPUT_RELEASE_GENERATED"], os.environ["INPUT_NEW_RELEASE_MAJOR_VERSION"], os.environ["INPUT_NEW_RELEASE_MINOR_VERSION"], os.environ["INPUT_NEW_RELEASE_PATCH_VERSION"]
+          tags = f"latest,{major}.{minor},{major}.{minor}.{patch}" if published else "latest"
+          print(f"::set-output name=tags::{tags}")
+
+      - name: Gather Docker Labels
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@55d3462 #v1.9.1
+        with:
+          images: ghcr.io/${{ github.repository }}
+
       - name: Build and Push to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,16 @@
+{
+    "branches": ["master"],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",
+        ["@semantic-release/changelog", {
+            "changelogFile": "CHANGELOG.md"
+        }],
+        "@semantic-release/github",
+        ["@semantic-release/npm", {
+            "npmPublish": false
+        }]
+    ],
+    "dryRun": false,
+    "debug": true
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,9 +7,7 @@
             "changelogFile": "CHANGELOG.md"
         }],
         "@semantic-release/github",
-        ["@semantic-release/npm", {
-            "npmPublish": false
-        }]
+        "@semantic-release/npm"
     ],
     "dryRun": false,
     "debug": true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,12 +6,12 @@
         ["@semantic-release/changelog", {
             "changelogFile": "CHANGELOG.md"
         }],
-        "@semantic-release/github",
         "@semantic-release/npm",
         ["@semantic-release/git", {
           "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
           "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
-        }]
+        }],
+        "@semantic-release/github"
     ],
     "dryRun": false,
     "debug": true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,11 @@
             "changelogFile": "CHANGELOG.md"
         }],
         "@semantic-release/github",
-        "@semantic-release/npm"
+        "@semantic-release/npm",
+        ["@semantic-release/git", {
+          "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
+          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+        }]
     ],
     "dryRun": false,
     "debug": true

--- a/README.md
+++ b/README.md
@@ -341,4 +341,4 @@ This API allows the developer to have complete control over the configuration an
 
 ## License
 
-This project is licensed under the [Apache 2.0](LICENSE) license using https://reuse.software best practice.
+This project is licensed under the [Apache 2.0](LICENSE) license.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prototypicalpro/repolinter.git"
+    "url": "https://github.com/todogroup/repolinter.git"
   },
   "dependencies": {
     "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/todogroup/repolinter.git"
+    "url": "https://github.com/prototypicalpro/repolinter.git"
   },
   "dependencies": {
     "ajv": "^6.12.6",


### PR DESCRIPTION
## Motivation

This PR builds on #196, but adds semantic-release to ensure that version tags are consistently updated for NPM, GitHub, and GHCR. A PAT of a user with package scopes in a `GHCR_PAT` secret and an NPM token in in a `NPM_TOKEN` secret  is required in order for this PR to work properly. 