### PR TITLE
Use full commit sha to get docker metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Gather Docker Labels
         if: steps.semantic.outputs.new_release_published == 'true'
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@55d3462 #v1.9.1
+        uses: crazy-max/ghaction-docker-meta@55d3462f059e0f1f2477ee4270665c7855d6b4ae #v1.9.1
         with:
           images: ghcr.io/${{ github.repository }}
 


### PR DESCRIPTION
See log in https://github.com/todogroup/repolinter/runs/2081128049

<img width="1050" alt="Screenshot 2021-03-11 at 09 40 59" src="https://user-images.githubusercontent.com/10019/110759435-e5893800-824d-11eb-9ac0-c8a3e9567969.png">

"Failed to resolve action download info. Error: Unable to resolve action `crazy-max/ghaction-docker-meta@55d3462`, the provided ref `55d3462` is the shortened version of a commit SHA, which is not supported. Please use the full commit SHA `55d3462f059e0f1f2477ee4270665c7855d6b4ae` instead."

## Motivation

The release has failed because github action requires a full sha1 when using github actions.

## Proposed Changes

Append the short SHA1 with the complete SHA1
