### PR TITLE
docs: fail-on-non-exist should be fail-on-non-existent

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -57,7 +57,7 @@ Checks if the contents of a file match a given regular expression.
 | `nocase`                 | No       | `boolean`  | `false`                             | Set to `true` to make the globs case insensitive. This does not effect the case sensitivity of the regular expression.                                                                                                           |
 | `flags`                  | No       | `string`   | `""`                                | The flags to use for the regular expression in `content` (ex. `"i"` for case insensitivity).                                                                                                                                     |
 | `human-readable-content` | No       | `string`   | The regular expression in `content` | The string to print instead of the regular expression when generating human-readable output.                                                                                                                                     |
-| `fail-on-non-exist`      | No       | `boolean`  | `false`                             | Set to `true` to disable passing if no files are found from `globsAll`.                                                                                                                                                          |
+| `fail-on-non-existent`      | No       | `boolean`  | `false`                             | Set to `true` to disable passing if no files are found from `globsAll`.                                                                                                                                                          |
 
 ### `file-existence`
 
@@ -107,7 +107,7 @@ Checks none of a given list of files match a given regular expression.
 | `nocase`                 | No       | `boolean`  | `false`                             | Set to `true` to make the globs case insensitive. This does not effect the case sensitivity of the regular expression.                                                                                                           |
 | `flags`                  | No       | `string`   | `""`                                | The flags to use for the regular expression in `content` (ex. `"i"` for case insensitivity).                                                                                                                                     |
 | `human-readable-content` | No       | `string`   | The regular expression in `content` | The string to print instead of the regular expression when generating human-readable output.                                                                                                                                     |
-| `fail-on-non-exist`      | No       | `boolean`  | `false`                             | Set to `true` to disable passing if no files are found from `globsAll`.                                                                                                                                                          |
+| `fail-on-non-existent`      | No       | `boolean`  | `false`                             | Set to `true` to disable passing if no files are found from `globsAll`.                                                                                                                                                          |
 
 ### `file-not-exists`
 

--- a/rules/file-contents-config.json
+++ b/rules/file-contents-config.json
@@ -14,7 +14,7 @@
     "content": { "type": "string" },
     "flags": { "type": "string" },
     "human-readable-content": { "type": "string" },
-    "fail-on-non-exist": {
+    "fail-on-non-existent": {
       "type": "boolean",
       "default": false
     }

--- a/rules/file-not-contents-config.json
+++ b/rules/file-not-contents-config.json
@@ -14,7 +14,7 @@
     "content": { "type": "string" },
     "flags": { "type": "string" },
     "human-readable-content": { "type": "string" },
-    "fail-on-non-exist": {
+    "fail-on-non-existent": {
       "type": "boolean",
       "default": false
     }


### PR DESCRIPTION
## Motivation

👋Hi there!
I was working on a new ruleset that we can use at Philips and noticed a small issue in the documentation regarding the _fail-on-non-existent_ option.  

## Proposed Changes

Change all inconsistencies regarding the fail-on-non-existent option in the docs and configs.

## Test Plan

Test if documentation still compiles.
