### PR TITLE
Update Docker Publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,8 +156,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Gather Docker Labels
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Gather Docker Labels
         if: steps.semantic.outputs.new_release_published == 'true'
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@55d3462 #v1.9.1
+        uses: crazy-max/ghaction-docker-meta@v1.12.0
         with:
           images: ghcr.io/${{ github.repository }}
 


### PR DESCRIPTION
This PR updates the short SHA of one of the actions to a versioned tag now that it exists. Actions no longer supports the short SHA for a named Action, as such post-merge CI is failing as it cannot checkout the Action.

This change also migrates from the custom PAT_TOKEN to the GITHUB_TOKEN now that the GHCR supports the GITHUB_TOKEN for push event authentication to the registry: https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/