### PR TITLE
ci: bump CI package versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -61,7 +61,7 @@ jobs:
 
       - name: Setup Ruby
         if: ${{ runner.os != 'Windows' }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
 
@@ -162,7 +162,7 @@ jobs:
       - name: Gather Docker Labels
         if: steps.semantic.outputs.new_release_published == 'true'
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1.12.0
+        uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: ghcr.io/${{ github.repository }}
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,9 +15,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '14'
 
       - name: Cache NPM
         id: cache-node-modules
@@ -37,8 +37,7 @@ jobs:
         run: npm run apidoc
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: apidoc # The folder the action should deploy.
+          branch: gh-pages # The branch the action should deploy to.
+          folder: apidoc # The folder the action should deploy.


### PR DESCRIPTION
This PR updates the CI package versions used by the repolinter GH Actions pipeline.
