### PR TITLE
run repolinter on repolinter using repolinter-action

### DIFF
--- a/.github/workflows/repolinter.yaml
+++ b/.github/workflows/repolinter.yaml
@@ -1,0 +1,9 @@
+name: repolinter
+on: [push, pull_request]
+
+jobs:
+  repolinter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: newrelic/repolinter-action@0e463abe6d591be494272ebb50a536dcb270bcfe #v1.6.5


### PR DESCRIPTION
for now, we're just using the default ruleset, since it covers the most common things, and it already passes.  We can certainly customize that down the road with other rules.  

If and when we do use a custom ruleset file, we're probably want to put it in the `.github` directory.  Even though it's common to have a `repolinter.json` file in the root of the project, because this is for the repolinter project itself, I think that might cause some issues with some new tests that are being added in a separate PR.  But none of that actually matters right now.

(relates to todogroup/work-day-activities#8)