### PR TITLE
ci: switch to setup-ruby for installing bundle gems

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,22 +64,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
-
-      - name: Cache Ruby Gems
-        if: ${{ runner.os != 'Windows' }}
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Install Ruby Dependencies
-        if: ${{ runner.os != 'Windows' }}
-        run: |
-          gem install --no-document bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Run Test
         if: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
This PR _should_ fix a bug with ruby gems in the CI pipline that is causing MacOS builds to fail.
