### PR TITLE
update repolinter github action

### DIFF
--- a/.github/repolinter.yaml
+++ b/.github/repolinter.yaml
@@ -1,0 +1,2 @@
+extends: https://raw.githubusercontent.com/todogroup/.github/master/repolinter-rules/default.yaml
+# Add custom repolinter rules here. Learn more at https://github.com/todogroup/repolinter

--- a/.github/workflows/repolinter.yaml
+++ b/.github/workflows/repolinter.yaml
@@ -6,4 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: newrelic/repolinter-action@0e463abe6d591be494272ebb50a536dcb270bcfe #v1.6.5
+    - uses: todogroup/repolinter-action@v1
+      with:
+        config_file: .github/repolinter.yaml


### PR DESCRIPTION
- switch to todogroup/repolinter-action
- use todogroup default repolinter ruleset

relates to todogroup/work-day-activities#8