### PR TITLE
Check Best Practices Badge present in README and optionally badge level

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -22,6 +22,7 @@ Below is a complete list of rules that Repolinter can run, along with their conf
   - [`git-working-tree`](#git-working-tree)
   - [`json-schema-passes`](#json-schema-passes)
   - [`license-detectable-by-licensee`](#license-detectable-by-licensee)
+  - [`best-practices-badge-present`](#best-practices-badge-present)
 
 ## Reference
 
@@ -195,3 +196,11 @@ Checks if a given file matches a provided [JSON schema](https://json-schema.org/
 ### `license-detectable-by-licensee`
 
 Fails if Licensee doesn't detect the repository's license. This rule takes no inputs, but requires `licensee` in the path, see [command line dependencies](#command-line-dependencies) for details.
+
+### `best-practices-badge-present`
+
+Check Best Practices Badge is present in README. Optionally check a certain badge level is accomplished.
+
+| Input        | Required | Type       | Default | Description                                                        |
+| ------------ | -------- | ---------- | ------- | ------------------------------------------------------------------ |
+| `minPercentage` | No       | `integer`  | `null` | Minimum [Tiered Percentage](https://github.com/coreinfrastructure/best-practices-badge/blob/main/doc/api.md#tiered-percentage-in-openssf-best-practices-badge) accomplished by project. `passing=100`, `silver=200`, `gold=300`, set to `0` or `null` to disable check. |

--- a/rules/best-practices-badge-present-config.json
+++ b/rules/best-practices-badge-present-config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/todogroup/repolinter/master/rules/best-practices-badge-present-config.json",
+  "type": "object",
+  "properties": {
+    "minPercentage": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}

--- a/rules/best-practices-badge-present.js
+++ b/rules/best-practices-badge-present.js
@@ -1,0 +1,38 @@
+// Copyright 2022 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const fetch = require('node-fetch')
+const Result = require('../lib/result')
+const fileContents = require('./file-contents')
+const bestPracticesRegExp =
+  'https://bestpractices\\.coreinfrastructure\\.org(/\\w+)?/projects/\\d+'
+
+module.exports = async function (fileSystem, options = {}) {
+  const readmeContainsBadge = await fileContents(fileSystem, {
+    globsAll: ['README*'],
+    content: bestPracticesRegExp,
+    nocase: true,
+    flags: 'i',
+    'fail-on-non-existent': true,
+    'human-readable-content': 'Best Practices Badge'
+  })
+  if (!readmeContainsBadge.passed || !options.minPercentage) {
+    return readmeContainsBadge
+  }
+  const readmePath = readmeContainsBadge.targets[0].path
+  const targets = [{ path: readmePath }]
+  const readmeContents = await fileSystem.getFileContents(readmePath)
+  const bestPracticesUrl = readmeContents.match(
+    new RegExp(bestPracticesRegExp, 'i')
+  )[0]
+  const bestPracticesResponse = await fetch(`${bestPracticesUrl}.json`)
+  if (!bestPracticesResponse.ok) {
+    return new Result('Invalid Best Practices Badge URL', targets, false)
+  }
+  const bestPracticesData = await bestPracticesResponse.json()
+  const passed = bestPracticesData.tiered_percentage >= options.minPercentage
+  const message = `Best Practices Badge ${
+    passed ? 'reached' : 'did not reach'
+  } minimum level`
+  return new Result(message, targets, passed)
+}

--- a/rules/rules.js
+++ b/rules/rules.js
@@ -3,6 +3,7 @@
 
 module.exports = [
   'apache-notice',
+  'best-practices-badge-present',
   'directory-existence',
   'file-contents',
   'file-existence',

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -282,6 +282,12 @@
           "fail-message": "The NOTICE file is described in section 4.4 of the Apache License version 2.0. Its presence is not mandated by the license itself, but by ASF policy."
         }
       }
+    },
+    "best-practices-badge-present": {
+      "level": "off",
+      "rule": {
+        "type": "best-practices-badge-present"
+      }
     }
   }
 }

--- a/rulesets/schema.json
+++ b/rulesets/schema.json
@@ -62,6 +62,18 @@
                 },
                 {
                   "if": {
+                    "properties": { "type": { "const": "bespractices-badge-present" } }
+                  },
+                  "then": {
+                    "properties": {
+                      "options": {
+                        "$ref": "../rules/best-practices-badge-present-config.json"
+                      }
+                    }
+                  }
+                },
+                {
+                  "if": {
                     "properties": { "type": { "const": "directory-existence" } }
                   },
                   "then": {

--- a/tests/rules/best_practices_badge_tests.js
+++ b/tests/rules/best_practices_badge_tests.js
@@ -1,0 +1,133 @@
+// Copyright 2022 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const chai = require('chai')
+const nock = require('nock')
+const expect = chai.expect
+
+describe('rule', () => {
+  describe('Best Practices Badge', () => {
+    const BestpracticesBadgePresent = require('../../rules/best-practices-badge-present')
+
+    it('fails if readme is missing', async () => {
+      const mockfs = {
+        findAllFiles: _ => [],
+        getFileContents: _ => null,
+        targetDir: '.'
+      }
+
+      const actual = await BestpracticesBadgePresent(mockfs)
+      expect(actual.passed).to.equal(false)
+      expect(actual.message).to.include('not find')
+    })
+
+    it('fails if readme does not contain the Best Practices Badge', async () => {
+      const mockfs = {
+        findAllFiles: _ => ['README'],
+        getFileContents: _ => '...',
+        targetDir: '.'
+      }
+
+      const actual = await BestpracticesBadgePresent(mockfs)
+      expect(actual.passed).to.equal(false)
+      expect(actual.targets.length).to.equal(1)
+      expect(actual.targets[0].message).to.equal(
+        "Doesn't contain Best Practices Badge"
+      )
+    })
+
+    it('passes if readme contains the Best Practices badge (URL with locale)', async () => {
+      const mockfs = {
+        findAllFiles: _ => ['README'],
+        getFileContents: _ =>
+          '[badge](https://bestpractices.coreinfrastructure.org/en/projects/100)',
+        targetDir: '.'
+      }
+
+      const actual = await BestpracticesBadgePresent(mockfs)
+      expect(actual.passed).to.equal(true)
+    })
+
+    it('passes if readme contains the Best Practices Badge (URL without locale)', async () => {
+      const mockfs = {
+        findAllFiles: _ => ['README'],
+        getFileContents: _ =>
+          '[badge](https://bestpractices.coreinfrastructure.org/projects/100)',
+        targetDir: '.'
+      }
+
+      const actual = await BestpracticesBadgePresent(mockfs)
+      expect(actual.passed).to.equal(true)
+    })
+
+    it('fails if readme contains the Best Practices Badge has invalid URL', async () => {
+      const mockfs = {
+        findAllFiles: _ => ['README'],
+        getFileContents: _ =>
+          'https://bestpractices.coreinfrastructure.org/en/projects/wrong',
+        targetDir: '.'
+      }
+
+      const actual = await BestpracticesBadgePresent(mockfs)
+      expect(actual.passed).to.equal(false)
+    })
+    describe('minPercentage', () => {
+      const mockfs = {
+        findAllFiles: _ => ['README'],
+        getFileContents: _ =>
+          '[badge](https://bestpractices.coreinfrastructure.org/projects/100)',
+        targetDir: '.'
+      }
+
+      it('passes when minPercentage is not set', async () => {
+        const actual = await BestpracticesBadgePresent(mockfs, {
+          minPercentage: null
+        })
+        expect(actual.passed).to.equal(true)
+      })
+
+      it('passes when minPercentage is set to 0', async () => {
+        const actual = await BestpracticesBadgePresent(mockfs, {
+          minPercentage: 0
+        })
+        expect(actual.passed).to.equal(true)
+      })
+
+      it('fails when minPercentage is > than percentage returned by API', async () => {
+        const scope = nock('https://bestpractices.coreinfrastructure.org')
+          .get('/projects/100.json')
+          .reply(200, { tiered_percentage: 99 })
+
+        const actual = await BestpracticesBadgePresent(mockfs, {
+          minPercentage: 100
+        })
+        expect(actual.passed).to.equal(false)
+        scope.done()
+      })
+
+      it('fails when minPercentage is set but API does not return 200', async () => {
+        const scope = nock('https://bestpractices.coreinfrastructure.org')
+          .get('/projects/100.json')
+          .reply(404)
+
+        const actual = await BestpracticesBadgePresent(mockfs, {
+          minPercentage: 100
+        })
+        expect(actual.passed).to.equal(false)
+        scope.done()
+      })
+
+      it('passes when minPercentage is <= than percentage returned by API', async () => {
+        const scope = nock('https://bestpractices.coreinfrastructure.org')
+          .get('/projects/100.json')
+          .reply(200, { tiered_percentage: 100 })
+
+        const actual = await BestpracticesBadgePresent(mockfs, {
+          minPercentage: 100
+        })
+        expect(actual.passed).to.equal(true)
+        scope.done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

Check Best Practices Badge is present in the README and optionally check the badge meets a desired level (passing, silver, gold, ...)

The rule is off by default to avoid breaking any repos using repolinter. 

## Proposed Changes

Add `best-practices-badge-present` rule, which will check there is a URL that looks like `https://bestpractices.coreinfrastructure.org/projects/$id` in the readme. The rule won't actually check that the badge has the right markdown, which would require to convert the markdown to html and then parse the html, but I think this solution is good enough.

Additionally, if the option `minPercentage` is passed as an option to the rule, the Best Practices Badge API will be queried with the URL found in the readme and we will assert that the `tiered_percentage` returned by the API is greater or equal to `minPercentage`. `tiered_percentage` maps to a Badge level; for instance `passing` is 100, `silver` 200 and `gold` 300. If no `minPercentage` is passed, the Badge level won't be checked and the API won't be called either. 

## Test Plan

Added 10 test cases in tests/rules/best_practices_badge_tests.js. When `minPercentage` is not passed as an option:

* FAIL if readme is missing
* FAIL if readme does not contain Best Practices Badge URL
* PASS if readme contains Best Practices Badge URL with locale, ie `/en/projects/$id`
* PASS if readme contains Best Practices Badge URL without locale, ie `/projects/$id`
* FAIL if readme contains malformed Best Practices Badge URL, ie `/projects/wrong`

When README has the Best Practices Badge URL:

* PASS if `minPercentage` is not set
* PASS if `minPercentage` is set to 0
* FAIL if `minPercentage` > `tiered_percentage` returned by API
* PASS if `minPercentage` <= `tiered_percentage` returned by API
* FAIL if API responds with an error.

