### PR TITLE
Bringing simple-git dep up to 3.15.0 to match package-lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "nock": "^13.0.5",
     "node-fetch": "^2.6.0",
     "rimraf": "^3.0.2",
-    "simple-git": "^3.5.0",
+    "simple-git": "^3.15.0",
     "yargs": "^15.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
After Dependabot updated the package-lock.json