### PR TITLE
Update versions of node in ci. Fixes ci.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['14', '12', '10']
+        node-version: ['19', '18', '16', '14']
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     name: Node ${{ matrix.node-version }} sample (${{ matrix.os }})

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Cache NPM
         id: cache-node-modules

--- a/tests/rules/git_grep_commits_tests.js
+++ b/tests/rules/git_grep_commits_tests.js
@@ -13,7 +13,7 @@ chai.use(require('chai-string'))
 
 describe('rule', () => {
   describe('git_grep_commits', function () {
-    this.timeout(30000) // Calling external Git might take some time.
+    this.timeout(40000) // Calling external Git might take some time.
 
     const gitGrepCommits = require('../../rules/git-grep-commits')
     const DIFF_CORRECT_CASE =


### PR DESCRIPTION
## Motivation

Update to supported versions of node.

Currently node 14, 16 and 18 are stable. See https://github.com/nodejs/release#release-schedule
Also added v19.6.1, because we're using `node:buster` in the `Dockerfile` which uses v19.6.1.

## Proposed Changes

This PR will:
- remove node 10 and 12 in CI
- add node (14), 16, 18, 19 in CI

## Test Plan

Ran tests ( `npm ci`, `npm test`, `npm apidoc` ) on macOs for:
- node v14.21.3
- node v16.19.1
- node v18.14.1
- node v19.6.1

## Related issue
closes: #270

