### PR TITLE
Update versions of node in Dockerfile. Fixes ci.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #
 #   docker run -t repolinter --git https://github.com/username/repo.git
 #
-FROM node:buster
+FROM node:bullseye
 
 ARG RUNTIME_DEPS="git libicu-dev perl python3 ruby-full locales patch ruby-dev"
 ARG BUILD_DEPS="make autoconf automake python3-pip curl liblzma-dev build-essential cmake pkg-config zlib1g-dev libcurl4-openssl-dev libssl-dev libldap2-dev libidn11-dev"


### PR DESCRIPTION

## Motivation

Currently the docker build is failing because of the usage of `node:buster` instead of `node:bullseye`. When installing `ruby` this defaults to an incompatible version.

## Proposed Changes

Switch to `node:bullseye`. When installing ruby it defaults to ruby 2.7, which is fine for us.

## Test Plan

Build the docker image locally.

```bash
$docker build -t repolinter .
```

Tested the docker image locally.

```bash
$docker run repolinter
```