### PR TITLE
Selective test run for git tests

### DIFF
--- a/lib/git_helper.js
+++ b/lib/git_helper.js
@@ -1,0 +1,14 @@
+const spawnSync = require('child_process').spawnSync
+
+/**
+ * @param targetDir
+ * @ignore
+ */
+function gitAllCommits(targetDir) {
+  const args = ['-C', targetDir, 'rev-list', '--all']
+  return spawnSync('git', args).stdout.toString().split('\n')
+}
+
+module.exports = {
+  gitAllCommits
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "nyc": "^15.1.0",
         "prettier": "2.2.0",
         "prettier-config-standard": "^1.0.1",
+        "sinon": "^15.0.1",
         "strip-ansi": "^6.0.0",
         "typescript": "^4.1.2",
         "unist-util-is": "^4.0.4"
@@ -792,6 +793,41 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "node_modules/@types/debug": {
       "version": "4.1.7",
@@ -4510,6 +4546,12 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4651,6 +4693,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -6207,6 +6255,19 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node_modules/nock": {
       "version": "13.2.9",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
@@ -6935,6 +6996,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -7922,6 +7998,24 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -10036,6 +10130,41 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+    },
+    "@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "@types/debug": {
       "version": "4.1.7",
@@ -12833,6 +12962,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -12947,6 +13082,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.merge": {
@@ -14035,6 +14176,19 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "nock": {
       "version": "13.2.9",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.9.tgz",
@@ -14558,6 +14712,23 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        }
+      }
     },
     "pathval": {
       "version": "1.1.1",
@@ -15261,6 +15432,20 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
+      }
+    },
+    "sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
       }
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "nyc": "^15.1.0",
     "prettier": "2.2.0",
     "prettier-config-standard": "^1.0.1",
+    "sinon": "^15.0.1",
     "strip-ansi": "^6.0.0",
     "typescript": "^4.1.2",
     "unist-util-is": "^4.0.4"

--- a/rules/git-grep-commits.js
+++ b/rules/git-grep-commits.js
@@ -6,9 +6,12 @@ const Result = require('../lib/result')
 // eslint-disable-next-line no-unused-vars
 const FileSystem = require('../lib/file_system')
 
+const GitHelper = require('../lib/git_helper')
+
 function listCommitsWithLines(fileSystem, options) {
   const pattern = '(' + options.denylist.join('|') + ')'
-  const commits = gitAllCommits(fileSystem.targetDir)
+
+  const commits = GitHelper.gitAllCommits(fileSystem.targetDir)
   return commits
     .map(commit => {
       return {
@@ -22,15 +25,6 @@ function listCommitsWithLines(fileSystem, options) {
       }
     })
     .filter(commit => commit.lines.length > 0)
-}
-
-/**
- * @param targetDir
- * @ignore
- */
-function gitAllCommits(targetDir) {
-  const args = ['-C', targetDir, 'rev-list', '--all']
-  return spawnSync('git', args).stdout.toString().trim().split('\n')
 }
 
 /**

--- a/rules/git-list-tree.js
+++ b/rules/git-list-tree.js
@@ -5,11 +5,7 @@ const spawnSync = require('child_process').spawnSync
 const Result = require('../lib/result')
 // eslint-disable-next-line no-unused-vars
 const FileSystem = require('../lib/file_system')
-
-function gitAllCommits(targetDir) {
-  const args = ['-C', targetDir, 'rev-list', '--all']
-  return spawnSync('git', args).stdout.toString().split('\n')
-}
+const GitHelper = require('../lib/git_helper')
 
 /**
  * @param targetDir
@@ -33,7 +29,7 @@ function listFiles(fileSystem, options) {
     '(' + options.denylist.join('|') + ')',
     options.ignoreCase ? 'i' : ''
   )
-  const commits = gitAllCommits(fileSystem.targetDir)
+  const commits = GitHelper.gitAllCommits(fileSystem.targetDir)
   commits.forEach(commit => {
     const includedFiles = gitFilesAtCommit(fileSystem.targetDir, commit)
       .filter(file => file.match(pattern))

--- a/tests/lib/git_helper_tests.js
+++ b/tests/lib/git_helper_tests.js
@@ -1,0 +1,20 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const chai = require('chai')
+const expect = chai.expect
+const GitHelper = require('../../lib/git_helper')
+
+describe('gitAllCommits', () => {
+  describe('git_grep_commits', function () {
+    const { gitAllCommits } = GitHelper
+
+    describe('full commits list', () => {
+      it('#gitAllCommits should return full list (> 100) of gitrefs', () => {
+        const FileSystem = require('../../lib/file_system')
+        const actual = gitAllCommits(new FileSystem().targetDir)
+        expect(actual).to.have.length.greaterThan(100)
+      })
+    })
+  })
+})

--- a/tests/rules/git_grep_commits_tests.js
+++ b/tests/rules/git_grep_commits_tests.js
@@ -7,15 +7,30 @@ chai.use(chaiEach)
 const expect = chai.expect
 // eslint-disable-next-line no-unused-vars
 const should = chai.should()
+const sinon = require('sinon')
 const FileSystem = require('../../lib/file_system')
+const GitHelper = require('../../lib/git_helper')
 
 chai.use(require('chai-string'))
 
 describe('rule', () => {
   describe('git_grep_commits', function () {
-    this.timeout(40000) // Calling external Git might take some time.
-
     const gitGrepCommits = require('../../rules/git-grep-commits')
+
+    before(function () {
+      const stubValue = [
+        '3e66e3ec616d59f813bdb878e1146d03872a096e',
+        'c9e1b59c86c119a5a67389ffd13d026c6058492a',
+        '260f8cc14d6ecf0ff1f0162f88086143d813967a'
+      ]
+
+      sinon.stub(GitHelper, 'gitAllCommits').returns(stubValue)
+    })
+
+    after(function () {
+      GitHelper.gitAllCommits.restore()
+    })
+
     const DIFF_CORRECT_CASE =
       'Copyright 2017 TODO Group\\. All rights reserved\\.'
     const DIFF_WRONG_CASE =

--- a/tests/rules/git_list_tree_tests.js
+++ b/tests/rules/git_list_tree_tests.js
@@ -7,12 +7,25 @@ chai.use(require('chai-string'))
 const expect = chai.expect
 // eslint-disable-next-line no-unused-vars
 const should = chai.should()
+const sinon = require('sinon')
 const FileSystem = require('../../lib/file_system')
+const GitHelper = require('../../lib/git_helper')
 
 describe('rule', () => {
   describe('git_list_tree', function () {
-    this.timeout(30000) // Calling external Git might take some time.
+    before(function () {
+      const stubValue = [
+        '3e66e3ec616d59f813bdb878e1146d03872a096e',
+        'c9e1b59c86c119a5a67389ffd13d026c6058492a',
+        '260f8cc14d6ecf0ff1f0162f88086143d813967a'
+      ]
 
+      sinon.stub(GitHelper, 'gitAllCommits').returns(stubValue)
+    })
+
+    after(function () {
+      GitHelper.gitAllCommits.restore()
+    })
     const gitListTree = require('../../rules/git-list-tree')
     const PATH_WRONG_CASE = 'rules/git-list-TREE\\.js'
 


### PR DESCRIPTION
## Motivation

Use [SinonJs](https://sinonjs.org/) stub for the `GitAllCommits` function to speed up the tests. The tests were performing the rules on a big repository with a lot of commits, and the timeout was hit very frequently.

Now this should be resolved.

Now the tests will only check the following three commits:

| Commit sha | test-case |
| --- | --- |
| `3e66e3ec616d59f813bdb878e1146d03872a096e` | `git_grep_commits` |
| `c9e1b59c86c119a5a67389ffd13d026c6058492a` |`git_grep_commits` |
| `260f8cc14d6ecf0ff1f0162f88086143d813967a` |`git_list_tree` |

## Proposed Changes

- Moved `gitAllCommits` in a Helper module.
- Add test for `gitAllCommits` to proof it still works.
- Use `gitAllCommits` in two slow tests.
- Stub results of `gitAllCommits` in tests with specific commits.

## Test Plan

### Ran various individual tests locally
```
./node_modules/mocha/bin/mocha.js tests/rules/git_grep_commits_tests.js
```

### Ran all tests locally
```
npm test
```
