### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @caniszczyk
 * @hyandell
-* @trevmex


### PR DESCRIPTION
Dropping Chris and Trevor as both are inactive. Note that future folk need to go on the same line, not in a list.

Resolving #284 