### PR TITLE
feat: add any-file-contents rule

### DIFF
--- a/rules/any-file-contents-config.json
+++ b/rules/any-file-contents-config.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://raw.githubusercontent.com/todogroup/repolinter/master/rules/any-file-contents-config.json",
+  "type": "object",
+  "properties": {
+    "nocase": {
+      "type": "boolean",
+      "default": false
+    },
+    "globsAny": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "branches": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "skipDefaultBranch": { "type": "boolean", "default": false },
+    "content": { "type": "string" },
+    "flags": { "type": "string" },
+    "human-readable-content": { "type": "string" },
+    "fail-on-non-existent": {
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "required": ["content"],
+  "oneOf": [{ "required": ["globsAny"] }, { "required": ["files"] }]
+}

--- a/rules/any-file-contents.js
+++ b/rules/any-file-contents.js
@@ -1,0 +1,21 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// eslint-disable-next-line no-unused-vars
+const Result = require('../lib/result')
+// eslint-disable-next-line no-unused-vars
+const FileSystem = require('../lib/file_system')
+const fileContents = require('./file-contents')
+
+/**
+ * Check that at least one file within a list contains a regular expression.
+ *
+ * @param {FileSystem} fs A filesystem object configured with filter paths and target directories
+ * @param {object} options The rule configuration
+ * @returns {Promise<Result>} The lint rule result
+ */
+function anyFileContents(fs, options) {
+  return fileContents(fs, options, false, true)
+}
+
+module.exports = anyFileContents

--- a/rules/file-contents.js
+++ b/rules/file-contents.js
@@ -32,9 +32,9 @@ function getContext(matchedLine, regexMatch, contextLength) {
  * @returns {Promise<Result>} The lint rule result
  * @ignore
  */
-async function fileContents(fs, options, not = false) {
+async function fileContents(fs, options, not = false, any = false) {
   // support legacy configuration keys
-  const fileList = options.globsAll || options.files
+  const fileList = (any ? options.globsAny : options.globsAll) || options.files
   const files = await fs.findAllFiles(fileList, !!options.nocase)
   const regexFlags = options.flags || ''
 
@@ -272,7 +272,9 @@ async function fileContents(fs, options, not = false) {
   }
 
   const filteredResults = results.filter(r => r !== null)
-  const passed = !filteredResults.find(r => !r.passed)
+  const passed = any
+    ? filteredResults.some(r => r.passed)
+    : !filteredResults.find(r => !r.passed)
   return new Result('', filteredResults, passed)
 }
 

--- a/tests/rules/any_file_contents_tests.js
+++ b/tests/rules/any_file_contents_tests.js
@@ -1,0 +1,137 @@
+// Copyright 2017 TODO Group. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const chai = require('chai')
+const expect = chai.expect
+const FileSystem = require('../../lib/file_system')
+
+describe('rule', () => {
+  describe('any_file_contents', () => {
+    const anyFileContents = require('../../rules/any-file-contents')
+
+    it('returns passes if requested file contents exists in exactly one file', async () => {
+      /** @type {any} */
+      const mockfs = {
+        findAllFiles() {
+          return ['x.md', 'CONTRIBUTING.md', 'README.md']
+        },
+        getFileContents(file) {
+          return file === 'README.md' ? 'foo' : 'bar'
+        },
+        targetDir: '.'
+      }
+      const ruleopts = {
+        globsAny: ['README*', 'x.md', 'CONTRIBUTING.md'],
+        content: '[abcdef][oO0][^q]'
+      }
+
+      const actual = await anyFileContents(mockfs, ruleopts)
+      expect(actual.passed).to.equal(true)
+      expect(actual.targets).to.have.length(3)
+      expect(actual.targets[2]).to.deep.include({
+        passed: true,
+        path: 'README.md'
+      })
+    })
+
+    it('returns passes if requested file contents exists in two files', async () => {
+      /** @type {any} */
+      const mockfs = {
+        findAllFiles() {
+          return ['x.md', 'CONTRIBUTING.md', 'README.md']
+        },
+        getFileContents(file) {
+          return file === 'README.md' ? 'bar' : 'foo'
+        },
+        targetDir: '.'
+      }
+      const ruleopts = {
+        globsAny: ['README*', 'x.md', 'CONTRIBUTING.md'],
+        content: '[abcdef][oO0][^q]'
+      }
+
+      const actual = await anyFileContents(mockfs, ruleopts)
+
+      expect(actual.passed).to.equal(true)
+      expect(actual.targets).to.have.length(3)
+      expect(actual.targets[0]).to.deep.include({
+        passed: true,
+        path: 'x.md'
+      })
+      expect(actual.targets[1]).to.deep.include({
+        passed: true,
+        path: 'CONTRIBUTING.md'
+      })
+      expect(actual.targets[2]).to.deep.include({
+        passed: false,
+        path: 'README.md'
+      })
+    })
+
+    it('returns fails if the requested file contents does not exist in any file', async () => {
+      /** @type {any} */
+      const mockfs = {
+        findAllFiles() {
+          return ['x.md', 'CONTRIBUTING.md', 'README.md']
+        },
+        getFileContents() {
+          return 'bar'
+        },
+        targetDir: '.'
+      }
+      const ruleopts = {
+        globsAny: ['README*', 'x.md', 'CONTRIBUTING.md'],
+        content: '[abcdef][oO0][^q]'
+      }
+
+      const actual = await anyFileContents(mockfs, ruleopts)
+      expect(actual.passed).to.equal(false)
+      expect(actual.targets).to.have.length(3)
+      expect(actual.targets[0]).to.deep.include({
+        passed: false,
+        path: 'x.md'
+      })
+      expect(actual.targets[1]).to.deep.include({
+        passed: false,
+        path: 'CONTRIBUTING.md'
+      })
+    })
+
+    it('returns failure if no file exists with failure flag enabled', async () => {
+      /** @type {any} */
+      const mockfs = {
+        findAllFiles() {
+          return []
+        },
+        getFileContents() {},
+        targetDir: '.'
+      }
+
+      const ruleopts = {
+        globsAny: ['README.md', 'READMOI.md'],
+        content: 'foo',
+        'fail-on-non-existent': true
+      }
+
+      const actual = await anyFileContents(mockfs, ruleopts)
+
+      expect(actual.passed).to.equal(false)
+    })
+
+    it('should handle broken symlinks', async () => {
+      const brokenSymlink = './tests/rules/broken_symlink_for_test'
+      const stat = require('fs').lstatSync(brokenSymlink)
+      expect(stat.isSymbolicLink()).to.equal(true)
+      const fs = new FileSystem(require('path').resolve('.'))
+
+      const ruleopts = {
+        globsAny: [brokenSymlink],
+        lineCount: 1,
+        patterns: ['something'],
+        'fail-on-non-existent': true
+      }
+      const actual = await anyFileContents(fs, ruleopts)
+      expect(actual.passed).to.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

The *file-contents* rule passes if **all** the files discovered include the content specified via a regular expression. However, for our use case we need to check whether the content is included in **at least one** of the discovered files.

## Proposed Changes

Add *any-file-contents* rule, which mimics the functionality of the *file-contents* rule. However, the *any-file-contents* rule features a *globsAny* option, instead of *globsAll*.

To reduce code duplication, the fileContents method (which implements the logic of the *file-contents* rule) is extended with an optional boolean parameter (called *any*). If this parameter has the value *true*, then the rule passes if and only if there is at least one file with content matching the regex. Otherwise, the rule passes if and only if all files include content matching the regex.
  
## Test Plan

- it returns passes if requested file contents exists in exactly one file
- it returns passes if requested file contents exists in two files
- it returns fails if the requested file contents does not exist in any file
- it returns failure if no file exists with failure flag enabled
- it should handle broken symlinks

Original Pull Request on: https://github.com/philips-forks/repolinter/pull/18
