### PR TITLE
fix: escape backslashes in JSON formatter output

### DIFF
--- a/formatters/json_formatter.js
+++ b/formatters/json_formatter.js
@@ -14,7 +14,7 @@ class JsonFormatter {
    * @returns {string} The formatted output
    */
   static formatOutput(output, dryRun) {
-    return JSON.stringify(output)
+    return JSON.stringify(output).replace(/\\/g, '\\\\')
   }
 }
 

--- a/tests/formatters/json_formatter_tests.js
+++ b/tests/formatters/json_formatter_tests.js
@@ -44,5 +44,32 @@ describe('formatters', () => {
       const successResult = jsonFormatter.formatOutput(result, false)
       expect(successResult).to.equal(expected)
     })
+    it('escapes backslashes to produce valid JSON', () => {
+      const jsonFormatter = require('../../formatters/json_formatter')
+
+      /** @type {import('../..').LintResult} */
+      const result = {
+        passed: true,
+        errored: false,
+        results: [
+          FormatResult.CreateLintOnly(
+            new RuleInfo('myrule', 'error', [], 'file-existence', {}),
+            new Result('Escaped: \\', [], true)
+          )
+        ],
+        targets: {
+          language: new Result('No language?', [], false)
+        },
+        params: {
+          targetDir: '.',
+          filterPaths: [],
+          ruleset: {}
+        }
+      }
+      const expected =
+        '{"passed":true,"errored":false,"results":[{"ruleInfo":{"name":"myrule","level":"error","where":[],"ruleType":"file-existence","ruleConfig":{}},"status":"PASSED","lintResult":{"message":"Escaped: \\\\\\\\","targets":[],"passed":true}}],"targets":{"language":{"message":"No language?","targets":[],"passed":false}},"params":{"targetDir":".","filterPaths":[],"ruleset":{}}}'
+      const successResult = jsonFormatter.formatOutput(result, false)
+      expect(successResult).to.equal(expected)
+    })
   })
 })


### PR DESCRIPTION
## Motivation

Our JSON-formatted ouput is not actually valid JSON when it is rendered with unescaped backslashes like ".+@.+\..+".

## Proposed Changes

The JsonFormatter uses `JSON.stringify()` to render its output, but it needs additional postprocessing to escape backslashes.

## Test Plan

I added a unit test to exercise this new expected behavior.