### PR TITLE
feat: update github pull request template locations

### DIFF
--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -182,6 +182,7 @@
             ".github/PULL_REQUEST_TEMPLATE*",
             ".github/pull_request_template.md",
             "docs/pull_request_template.md",
+            "docs/PULL_REQUEST_TEMPLATE*",
             "pull_request_template.md"
           ]
         }

--- a/rulesets/default.json
+++ b/rulesets/default.json
@@ -179,7 +179,10 @@
           "dirs": true,
           "globsAny": [
             "PULL_REQUEST_TEMPLATE*",
-            ".github/PULL_REQUEST_TEMPLATE*"
+            ".github/PULL_REQUEST_TEMPLATE*",
+            ".github/pull_request_template.md",
+            "docs/pull_request_template.md",
+            "pull_request_template.md"
           ]
         }
       }


### PR DESCRIPTION
Include GitHub [documented](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) locations for pull request templates.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

Fixes: https://github.com/todogroup/repolinter/issues/321
GitHub documents other locations for a pull request template.


## Proposed Changes

Update the list of pull request template locations to match the documentation.

## Test Plan

Run the code on various repositories with additional locations.
