### PR TITLE
chore: check for package updates using dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

I use repolinter in my devDependencies in order to check my repository. I've gotten a couple of security notifications from GitHub due to third-party libraries linked to repolinter. This change should help trying to keep dependencies up-to-date.

## Proposed Changes

This will use dependabot to check for package udpates on a monthly basis. If there are any updates, dependabot will submit a pull request with a version bump.

## Test Plan

There should be several pull requests made from dependabot.
