### PR TITLE
Fix default ruleset link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Repolinter will pull its configuration from the following sources in order of pr
 
 1. A ruleset specified with `--rulesetFile` or `--rulesetUrl`
 2. A `repolint.json`, `repolinter.json`, `repolint.yaml`, or `repolinter.yaml` file at the root of the project being linted
-3. The [default ruleset](./rulesets/default.json)
+3. The [default ruleset](https://github.com/todogroup/repolinter/blob/main/rulesets/default.json) ([raw](https://raw.githubusercontent.com/todogroup/repolinter/refs/heads/main/rulesets/default.json))
 
 ### Creating a Ruleset
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

@sundhar22 pointed out in #331 that the link in the GitHub Page view of the site is not working.

## Proposed Changes

Change the link URL from relative (which works when viewed through the repo but not the Page) to an absolute URL (which works correctly in both locations).

## Test Plan

